### PR TITLE
Add valid values for RetentionInDays

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -15,6 +15,24 @@ Parameters:
   RetentionInDays:
     Type: Number
     Description: The number of days to set the expiry to on Cloudwatch Logs groups
+    AllowedValues:
+      - 1
+      - 3
+      - 5
+      - 7
+      - 14
+      - 30
+      - 60
+      - 90
+      - 120
+      - 150
+      - 180
+      - 365
+      - 400
+      - 545
+      - 731
+      - 1827
+      - 3653
 
   ShippingPrefix:
     Type: CommaDelimitedList


### PR DESCRIPTION
I was tripped up when I chose a number which was not supported:

![RetentionInDays](https://user-images.githubusercontent.com/9820960/62470865-452a8200-b793-11e9-8f67-52cdf4a2d64c.jpg)

See [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-loggroup.html](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-loggroup.html)