### PR TITLE
chore: Add more logging to track what is being sent to Kibana

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 riff-raff-artifact/
+.idea

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,9 +73,9 @@
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
+        "base64-js": "1.3.0",
+        "ieee754": "1.1.12",
+        "isarray": "1.0.0"
       }
     },
     "ieee754": {
@@ -119,8 +119,8 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "sax": "1.2.4",
+        "xmlbuilder": "9.0.7"
       }
     },
     "xmlbuilder": {

--- a/src/shipLogEntries.ts
+++ b/src/shipLogEntries.ts
@@ -162,11 +162,11 @@ function createStructuredLog(logGroup: string, logEvent: CloudWatchLogsLogEvent,
 }
 
 export async function shipLogEntries(event: CloudWatchLogsEvent, context: Context): Promise<void> {
-    
-
     const payload = new Buffer(event.awslogs.data, 'base64');
     const json = zlib.gunzipSync(payload).toString('utf8');
     const decoded: CloudWatchLogsDecodedData = JSON.parse(json);
+
+    console.log('decoded CloudWatch logs to forward', decoded);
 
     const logGroup = decoded.logGroup;
     const extraFields: StructuredFields = 


### PR DESCRIPTION
This commit adds some logging to show what is actually being sent to Kibana. This helps with identifying whether logs have successfully made their way to Kibana.