### PR TITLE
If the target is different from the current target then update

### DIFF
--- a/src/cloudwatch.ts
+++ b/src/cloudwatch.ts
@@ -19,7 +19,7 @@ async function getAllLogGroups(cloudwatchLogs: CloudWatchLogs, logGroupNamePrefi
 export async function subscribeGroups(cloudwatchLogs: CloudWatchLogs, groups: CloudWatchLogs.LogGroup[], filterName: string, targetLambda: string): Promise<void> {
     await Promise.all(groups.map(async (group) => {
         const subscriptions = await getSubscriptions(cloudwatchLogs, group.logGroupName!, filterName);
-        const subscriptionExists = subscriptions.some(sub => sub.filterName === filterName);
+        const subscriptionExists = subscriptions.some(sub => sub.filterName === filterName && sub.destinationArn === targetLambda);
         if (!subscriptionExists) {
             console.log(`Adding subscription for ${group.logGroupName!} with name ${filterName}`);
             await putSubscription(cloudwatchLogs, group.logGroupName!, filterName, targetLambda);


### PR DESCRIPTION
Under some circumstances you might end up with the target changing (i.e. if the Lambda is changed due to some type of redeployment). In this scenario we don't currently update the target as it already exists.

We should compare both the filter name and also the target of the filter so that we update when necessary.