### PR TITLE
Don't use deprecated method for constructing a buffer

### DIFF
--- a/src/shipLogEntries.ts
+++ b/src/shipLogEntries.ts
@@ -162,7 +162,7 @@ function createStructuredLog(logGroup: string, logEvent: CloudWatchLogsLogEvent,
 }
 
 export async function shipLogEntries(event: CloudWatchLogsEvent, context: Context): Promise<void> {
-    const payload = new Buffer(event.awslogs.data, 'base64');
+    const payload = Buffer.from(event.awslogs.data, 'base64');
     const json = zlib.gunzipSync(payload).toString('utf8');
     const decoded: CloudWatchLogsDecodedData = JSON.parse(json);
 


### PR DESCRIPTION
## What does this change?

Uses constructor `Buffer.from(...)` instead of `new Buffer(...)`. Change is on response to these log messages:

```
DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```

Resolves #25.
