### PR TITLE
PutRecords to submit at most 500 records per call

### DIFF
--- a/src/kinesis.ts
+++ b/src/kinesis.ts
@@ -1,15 +1,25 @@
 import { Kinesis } from "aws-sdk";
-import { PutRecordsRequestEntry } from "aws-sdk/clients/kinesis";
+import { PutRecordsOutput, PutRecordsRequestEntry } from "aws-sdk/clients/kinesis";
 
-export async function putKinesisRecords(kinesis: Kinesis, streamName: string, logEntries: PublishableStructuredLogData[]): Promise<void> {
+export async function putKinesisRecords(kinesis: Kinesis, streamName: string, logEntries: PublishableStructuredLogData[]): Promise<PutRecordsOutput[]> {
     const records: PutRecordsRequestEntry[] = logEntries.map((entry) => {
         return {
             Data: JSON.stringify(entry),
             PartitionKey: entry.cloudwatchId
         }
     });
-    await kinesis.putRecords({
-        Records: records,
+
+    // Batch records since each put record request supports at most 500 records
+    // https://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecords.html
+    const batchRecords: PutRecordsRequestEntry[][] = [];
+    while (records.length > 0) {
+        batchRecords.push(records.splice(0, 500));
+    }
+
+    const results = batchRecords.map(batch => kinesis.putRecords({
+        Records: batch,
         StreamName: streamName,
-    }).promise();
+    }).promise());
+
+    return await Promise.all(results);
 }


### PR DESCRIPTION
## What does this change?

Ensure that no more than 500 records are submitted in a PutRecords request. See in-line comments or #24 for more context.

Resolves #24.
