### PR TITLE
If a level is provided then honour it

### DIFF
--- a/src/shipLogEntries.ts
+++ b/src/shipLogEntries.ts
@@ -119,10 +119,12 @@ function parseNodeLogFormat(logGroup: string, line: String): StructuredLogData |
         const message = messageParts.join('\t')
         const structuredLog = parseMessageJson(message);
         return {
+            // put level first so it can be overriden if structured log contains level
+            level,
             ...structuredLog,
             //timestamp: dateString, // this makes it explode for some reason
+            // put lambdaRequestId last so it can never be overwritten
             lambdaRequestId,
-            level,
         }
     }
 }


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
When a node lambda logs via stdout or stderr cloudwatch puts either INFO or ERROR into the log line. This is super helpful but some applications might like to provide an explicit level in the JSON message they send. If they do this then it should be honoured but at the moment the cloudwatch level takes precedence.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
On PROD there are currently no WARN level messages but after deploying this there will be.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
I expect errors and warnings in ELK to increase as we are preserving them properly.