### PR TITLE
Consistently use 10 retries for AWS SDK

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -5,11 +5,11 @@ import { getCommonConfig, getSetRetentionConfig, getConfigureLogShippingConfig }
 import { getCloudWatchLogGroups, setCloudwatchRetention, subscribeGroups, unsubscribeGroups } from "./cloudwatch";
 import { updateStructuredFieldsData } from './structuredFields';
 
-const { region } = getCommonConfig();
+const { awsConfig } = getCommonConfig();
 
-const cloudwatchLogs = new CloudWatchLogs({ region, maxRetries: 10 });
-const s3 = new S3({ region });
-const lambda = new Lambda({ region });
+const cloudwatchLogs = new CloudWatchLogs(awsConfig);
+const s3 = new S3(awsConfig);
+const lambda = new Lambda(awsConfig);
 
 function sleep(ms: number){
     return new Promise(resolve=>{

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,7 @@
+import { ConfigurationOptions } from "aws-sdk/lib/config";
+
 interface CommonConfig {
-    region: string,
+    awsConfig: ConfigurationOptions,
 }
 
 interface SetRetentionConfig {
@@ -39,8 +41,12 @@ function getRequiredEnv(key: string, devDefault: string | undefined = undefined)
 
 export function getCommonConfig(): CommonConfig {
     const region = getRequiredEnv("AWS_REGION");
+    const maxRetries = parseInt(getRequiredEnv("AWS_RETRIES", "10"));
     return {
-        region,
+        awsConfig: {
+            region,
+            maxRetries: maxRetries
+        }
     };
 }
 

--- a/src/shipLogEntries.ts
+++ b/src/shipLogEntries.ts
@@ -7,14 +7,15 @@ import { getCommonConfig, getShipLogsConfig } from './config';
 import { putKinesisRecords } from './kinesis';
 import { getStructuredFields } from './structuredFields';
 import { PutRecordsOutput } from 'aws-sdk/clients/kinesis';
+import { ConfigurationOptions } from 'aws-sdk/lib/config';
 
-const { region } = getCommonConfig();
+const { awsConfig } = getCommonConfig();
 const { kinesisStreamName, kinesisStreamRole, structuredDataBucket, structuredDataKey } = getShipLogsConfig();
 
-const s3 = new S3({ region });
-const kinesis = getKinesisClient(region, kinesisStreamRole);
+const s3 = new S3(awsConfig);
+const kinesis = getKinesisClient(awsConfig, kinesisStreamRole);
 
-function getKinesisClient(region: string, role: string | undefined): Kinesis {
+function getKinesisClient(awsConfig: ConfigurationOptions, role: string | undefined): Kinesis {
     if (!!role) {
         const credentials = new ChainableTemporaryCredentials({
             params: {
@@ -22,9 +23,9 @@ function getKinesisClient(region: string, role: string | undefined): Kinesis {
                 RoleSessionName: `shipLogEntries-lambda`
              }
         })
-        return new Kinesis({ region, maxRetries: 10, credentials });
+        return new Kinesis({ ...awsConfig, credentials });
     } else {
-        return new Kinesis({ region, maxRetries: 10 });
+        return new Kinesis(awsConfig);
     }
 }
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Whilst some of the AWS SDK clients used maxRetries 10, some did not and errors were visible in central ELK. This restructures the code a little to consistently use a common configuration.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
When deployed this should eliminate the invoke errors currently seen in the `set-log-shipping` lambda.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
This ELK view should diminish to nothing: https://logs.gutools.co.uk/goto/875a22b0bea4e5545c1ff8b3d4474acf
