### PR TITLE
Disable events as they were firing far too noisily

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -117,24 +117,11 @@ Resources:
         Variables:
           RETENTION_IN_DAYS: !Ref RetentionInDays
       Events:
-        LogGroupChangeEvent:
-          Type: CloudWatchEvent
-          Properties:
-            Pattern:
-              source:
-              - aws.logs
-              detail-type:
-              - AWS API Call via CloudTrail
-              detail:
-                eventSource:
-                - logs.amazonaws.com
-                eventName:
-                - CreateLogGroup
-        # lets assume that we've missed an event and call it once a day as well
+        # call it once an hour
         CheckStatusEvent:
           Type: Schedule
           Properties:
-            Schedule: rate(1 day) 
+            Schedule: rate(1 hour)
       Tags:
         Stack: !Ref Stack
         Stage: !Ref Stage
@@ -182,21 +169,7 @@ Resources:
           STRUCTURED_DATA_BUCKET: !Ref StructuredFieldsBucket
           OPTION_LOWER_FIRST_CHAR_OF_TAGS: !Ref OptionLowerFirstCharOfTags
       Events:
-        # Trigger whenever a log group is created
-        LogGroupChangeEvent:
-          Type: CloudWatchEvent
-          Properties:
-            Pattern:
-              source:
-              - aws.logs
-              detail-type:
-              - AWS API Call via CloudTrail
-              detail:
-                eventSource:
-                - logs.amazonaws.com
-                eventName:
-                - CreateLogGroup
-        # tag changes on lambdas can't be triggered this way yet so update every 10 mins anyway
+        # Update every 10 mins
         CheckStatusEvent:
           Type: Schedule
           Properties:


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
The CreateLogGroup call was being done a lot to try and recreate existing logs (particularly in frontend). Looked briefly at trying to improve the pattern but this seems very difficult so here we are simply falling back on schedules only. Keep it simple I guess.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Fewer errors in the ELK console.