### PR TITLE
Unit test some of the log processing functionality

### DIFF
--- a/src/logEntryProcessing.test.ts
+++ b/src/logEntryProcessing.test.ts
@@ -1,11 +1,23 @@
-import { isRequestLogEntry } from './logEntryProcessing';
+import { fieldValue, isRequestLogEntry } from './logEntryProcessing';
 
 test('AWS Lambda Function reports are identified as request log entries', () => {
-    const logLine = "REPORT RequestId: 6fcf3b62-bdcb-4fd1-a8ac-4388dfd4784c Duration: 803.21 ms Billed Duration: 804 ms Memory Size: 256 MB Max Memory Used: 219 MB"
+    const logLine = 'REPORT RequestId: b1f86b7f-67b8-45a8-926b-1699f0f7ccae\tDuration: 1028.81 ms\tBilled Duration: 1029 ms\tMemory Size: 1024 MB\tMax Memory Used: 220 MB\t';
     expect(isRequestLogEntry(logLine)).toBe(true)
 })
 
 test('Custom log lines are not identified as request log entries', () => {
-    const logLine = "There was an error when fetching data from CAPI"
+    const logLine = 'There was an error when fetching data from CAPI';
     expect(isRequestLogEntry(logLine)).toBe(false)
+})
+
+test('Extracts a request ID correctly', () => {
+    const logLine = 'REPORT RequestId: b1f86b7f-67b8-45a8-926b-1699f0f7ccae\tDuration: 1028.81 ms\tBilled Duration: 1029 ms\tMemory Size: 1024 MB\tMax Memory Used: 220 MB\t';
+    const expected = 'b1f86b7f-67b8-45a8-926b-1699f0f7ccae';
+    expect(fieldValue(logLine, 'RequestId:', 36)).toBe(expected)
+})
+
+test('Extracts version correctly', () => {
+    const logLine = 'START RequestId: b1f86b7f-67b8-45a8-926b-1699f0f7ccae Version: $LATEST';
+    const expected = '$LATEST';
+    expect(fieldValue(logLine, 'Version:')).toBe(expected)
 })

--- a/src/logEntryProcessing.test.ts
+++ b/src/logEntryProcessing.test.ts
@@ -1,4 +1,4 @@
-import { fieldValue, isRequestLogEntry, lambdaRequestLogData, parseMessageJson, parseReportField } from './logEntryProcessing';
+import { fieldValue, isRequestLogEntry, lambdaRequestLogData, parseMessageJson, parseNodeLogFormat, parseReportField } from './logEntryProcessing';
 
 test('AWS Lambda Function reports are identified as request log entries', () => {
     const logLine = 'REPORT RequestId: b1f86b7f-67b8-45a8-926b-1699f0f7ccae\tDuration: 1028.81 ms\tBilled Duration: 1029 ms\tMemory Size: 1024 MB\tMax Memory Used: 220 MB\t';
@@ -90,4 +90,15 @@ test('Handles non-JSON log lines gracefully', () => {
         message: logLine
     }
     expect(parseMessageJson(logLine)).toStrictEqual(expected)
+})
+
+test('Handles node log format gracefully', () => {
+    const logGroup = '/aws/lambda/app-name-PROD';
+    const logLine = '2021-03-17\tb1f86b7f-67b8-45a8-926b-1699f0f7ccae\tERROR\tThere was an error when fetching data from CAPI';
+    const expected = {
+        level: 'ERROR',
+        message: 'There was an error when fetching data from CAPI',
+        lambdaRequestId: 'b1f86b7f-67b8-45a8-926b-1699f0f7ccae'
+    }
+    expect(parseNodeLogFormat(logGroup, logLine)).toStrictEqual(expected)
 })

--- a/src/logEntryProcessing.test.ts
+++ b/src/logEntryProcessing.test.ts
@@ -13,11 +13,11 @@ test('Custom log lines are not identified as request log entries', () => {
 test('Extracts a request ID correctly', () => {
     const logLine = 'REPORT RequestId: b1f86b7f-67b8-45a8-926b-1699f0f7ccae\tDuration: 1028.81 ms\tBilled Duration: 1029 ms\tMemory Size: 1024 MB\tMax Memory Used: 220 MB\t';
     const expected = 'b1f86b7f-67b8-45a8-926b-1699f0f7ccae';
-    expect(fieldValue(logLine, 'RequestId:', 36)).toBe(expected)
+    expect(fieldValue(logLine, 'RequestId', 36)).toBe(expected)
 })
 
 test('Extracts version correctly', () => {
     const logLine = 'START RequestId: b1f86b7f-67b8-45a8-926b-1699f0f7ccae Version: $LATEST';
     const expected = '$LATEST';
-    expect(fieldValue(logLine, 'Version:')).toBe(expected)
+    expect(fieldValue(logLine, 'Version')).toBe(expected)
 })

--- a/src/logEntryProcessing.test.ts
+++ b/src/logEntryProcessing.test.ts
@@ -1,4 +1,13 @@
-import { fieldValue, isRequestLogEntry, lambdaRequestLogData, parseMessageJson, parseNodeLogFormat, parseReportField } from './logEntryProcessing';
+import {
+    fieldValue,
+    isRequestLogEntry,
+    lambdaRequestLogData,
+    parseLambdaLogLine,
+    parseMessageJson,
+    parseNodeLogFormat,
+    parseReportField
+} from './logEntryProcessing';
+import {log} from "util";
 
 test('AWS Lambda Function reports are identified as request log entries', () => {
     const logLine = 'REPORT RequestId: b1f86b7f-67b8-45a8-926b-1699f0f7ccae\tDuration: 1028.81 ms\tBilled Duration: 1029 ms\tMemory Size: 1024 MB\tMax Memory Used: 220 MB\t';
@@ -101,4 +110,41 @@ test('Handles node log format gracefully', () => {
         lambdaRequestId: 'b1f86b7f-67b8-45a8-926b-1699f0f7ccae'
     }
     expect(parseNodeLogFormat(logGroup, logLine)).toStrictEqual(expected)
+})
+
+test('Correctly identifies and returns parsed AWS Lambda Function reports', () => {
+    const logGroup = '/aws/lambda/app-name-PROD';
+    const logLine = 'REPORT RequestId: b1f86b7f-67b8-45a8-926b-1699f0f7ccae\tDuration: 1028.81 ms\tBilled Duration: 1029 ms\tMemory Size: 1024 MB\tMax Memory Used: 220 MB\t';
+    const expected = {
+        lambdaEvent: 'REPORT',
+        lambdaRequestId: 'b1f86b7f-67b8-45a8-926b-1699f0f7ccae',
+        lambdaStats: {
+            billedDurationms: 1029,
+            durationms: 1028.81,
+            maxMemoryUsedMB: 220,
+            memorySizeMB: 1024,
+        },
+        message: 'REPORT RequestId: b1f86b7f-67b8-45a8-926b-1699f0f7ccae\tDuration: 1028.81 ms\tBilled Duration: 1029 ms\tMemory Size: 1024 MB\tMax Memory Used: 220 MB\t'
+    }
+    expect(parseLambdaLogLine(logGroup, logLine)).toStrictEqual(expected)
+})
+
+test('Correctly identifies and returns parsed node log lines', () => {
+    const logGroup = '/aws/lambda/app-name-PROD';
+    const logLine = '2021-03-17\tb1f86b7f-67b8-45a8-926b-1699f0f7ccae\tERROR\tThere was an error when fetching data from CAPI';
+    const expected = {
+        level: 'ERROR',
+        message: 'There was an error when fetching data from CAPI',
+        lambdaRequestId: 'b1f86b7f-67b8-45a8-926b-1699f0f7ccae'
+    }
+    expect(parseLambdaLogLine(logGroup, logLine)).toStrictEqual(expected)
+})
+
+test('Correctly identifies and returns parsed custom log lines', () => {
+    const logGroup = '/aws/lambda/app-name-PROD';
+    const logLine = 'There was an error when fetching data from CAPI';
+    const expected = {
+        message: logLine
+    }
+    expect(parseLambdaLogLine(logGroup, logLine)).toStrictEqual(expected)
 })

--- a/src/logEntryProcessing.test.ts
+++ b/src/logEntryProcessing.test.ts
@@ -1,4 +1,4 @@
-import { fieldValue, isRequestLogEntry } from './logEntryProcessing';
+import { fieldValue, isRequestLogEntry, parseReportField } from './logEntryProcessing';
 
 test('AWS Lambda Function reports are identified as request log entries', () => {
     const logLine = 'REPORT RequestId: b1f86b7f-67b8-45a8-926b-1699f0f7ccae\tDuration: 1028.81 ms\tBilled Duration: 1029 ms\tMemory Size: 1024 MB\tMax Memory Used: 220 MB\t';
@@ -20,4 +20,16 @@ test('Extracts version correctly', () => {
     const logLine = 'START RequestId: b1f86b7f-67b8-45a8-926b-1699f0f7ccae Version: $LATEST';
     const expected = '$LATEST';
     expect(fieldValue(logLine, 'Version')).toBe(expected)
+})
+
+test('Parses numeric fields from AWS Lambda Function reports', () => {
+    const durationField = 'Duration: 1028.81 ms';
+    const expected = ['durationms', 1028.81];
+    expect(parseReportField(durationField)).toStrictEqual(expected)
+})
+
+test('Parses non-numeric fields from AWS Lambda Function reports', () => {
+    const requestIdField = 'RequestId: b1f86b7f-67b8-45a8-926b-1699f0f7ccae';
+    const expected = ['requestId', 'b1f86b7f-67b8-45a8-926b-1699f0f7ccae'];
+    expect(parseReportField(requestIdField)).toStrictEqual(expected)
 })

--- a/src/logEntryProcessing.test.ts
+++ b/src/logEntryProcessing.test.ts
@@ -1,4 +1,4 @@
-import { fieldValue, isRequestLogEntry, lambdaRequestLogData, parseReportField } from './logEntryProcessing';
+import { fieldValue, isRequestLogEntry, lambdaRequestLogData, parseMessageJson, parseReportField } from './logEntryProcessing';
 
 test('AWS Lambda Function reports are identified as request log entries', () => {
     const logLine = 'REPORT RequestId: b1f86b7f-67b8-45a8-926b-1699f0f7ccae\tDuration: 1028.81 ms\tBilled Duration: 1029 ms\tMemory Size: 1024 MB\tMax Memory Used: 220 MB\t';
@@ -74,4 +74,20 @@ test('Builds the correct StructuredLogData for REPORT events', () => {
 test('Does not attempt to build StructuredLogData for custom events', () => {
     const logLine = 'There was an error when fetching data from CAPI';
     expect(lambdaRequestLogData(logLine)).toStrictEqual(undefined)
+})
+
+test('Parses JSON log lines successfully', () => {
+    const logLine = '{ "test": "value" }';
+    const expected = {
+        test: 'value'
+    }
+    expect(parseMessageJson(logLine)).toStrictEqual(expected)
+})
+
+test('Handles non-JSON log lines gracefully', () => {
+    const logLine = 'There was an error when fetching data from CAPI';
+    const expected = {
+        message: logLine
+    }
+    expect(parseMessageJson(logLine)).toStrictEqual(expected)
 })

--- a/src/logEntryProcessing.ts
+++ b/src/logEntryProcessing.ts
@@ -15,7 +15,7 @@ export function fieldValue(text: string, fieldNameText: string, valueLength?: nu
  * Parse an AWS lambda report field into a field name and a value
  * @param rawField The raw field that looks something like "Field Name: value unit"
  */
-function parseReportField(rawField: string): [string, any] {
+export function parseReportField(rawField: string): [string, any] {
     const [rawFieldName, rawFieldValue] = rawField.split(':').map(s => s.trim());
 
     const fieldNameNoSpaces = rawFieldName.replace(/ /g, '');

--- a/src/logEntryProcessing.ts
+++ b/src/logEntryProcessing.ts
@@ -84,7 +84,7 @@ export function parseMessageJson(line: string): StructuredLogData {
 }
 
 // this parses a log line of the format <date>\t<requestId>\t<level>\t<message>
-function parseNodeLogFormat(logGroup: string, line: String): StructuredLogData | undefined {
+export function parseNodeLogFormat(logGroup: string, line: String): StructuredLogData | undefined {
     const elements = line.split('\t');
     const [dateString, lambdaRequestId, level, ...messageParts] = elements;
     const isDate = !isNaN(Date.parse(dateString));

--- a/src/logEntryProcessing.ts
+++ b/src/logEntryProcessing.ts
@@ -23,7 +23,7 @@ export function parseReportField(rawField: string): [string, any] {
 
     const [value, unit] = rawFieldValue.split(' ');
 
-    if (unit == 'ms' || unit == 'MB') {
+    if (unit === 'ms' || unit === 'MB') {
         // value should be numeric
         const numericValue = parseFloat(value);
         return [fieldName + unit, numericValue] as [string, any];

--- a/src/logEntryProcessing.ts
+++ b/src/logEntryProcessing.ts
@@ -6,7 +6,7 @@ export function isRequestLogEntry(line: string): boolean {
         line.startsWith('REPORT RequestId: ')
 }
 
-function fieldValue(text: string, fieldNameText: string, valueLength?: number): string {
+export function fieldValue(text: string, fieldNameText: string, valueLength?: number): string {
     return text.substr(text.indexOf(fieldNameText)+fieldNameText.length, valueLength).trim();
 }
 

--- a/src/logEntryProcessing.ts
+++ b/src/logEntryProcessing.ts
@@ -73,7 +73,7 @@ export function lambdaRequestLogData(line: string): StructuredLogData | undefine
     }
 }
 
-function parseMessageJson(line: string): StructuredLogData {
+export function parseMessageJson(line: string): StructuredLogData {
     try {
         return JSON.parse(line.trim());
     } catch (err) {

--- a/src/logEntryProcessing.ts
+++ b/src/logEntryProcessing.ts
@@ -33,7 +33,7 @@ export function parseReportField(rawField: string): [string, any] {
     }
 }
 
-function lambdaRequestLogData(line: string): StructuredLogData | undefined {
+export function lambdaRequestLogData(line: string): StructuredLogData | undefined {
     if (isRequestLogEntry(line)) {
         const eventName = line.substr(0, line.indexOf(' '));
         const requestId = fieldValue(line, 'RequestId', 36);

--- a/src/logEntryProcessing.ts
+++ b/src/logEntryProcessing.ts
@@ -1,5 +1,138 @@
+import { CloudWatchLogsLogEvent } from 'aws-lambda';
+
 export function isRequestLogEntry(line: string): boolean {
     return line.startsWith('START RequestId: ') ||
         line.startsWith('END RequestId: ') ||
         line.startsWith('REPORT RequestId: ')
+}
+
+function fieldValue(text: string, fieldNameText: string, valueLength?: number): string {
+    return text.substr(text.indexOf(fieldNameText)+fieldNameText.length, valueLength).trim();
+}
+
+/**
+ * Parse an AWS lambda report field into a field name and a value
+ * @param rawField The raw field that looks something like "Field Name: value unit"
+ */
+function parseReportField(rawField: string): [string, any] {
+    const [rawFieldName, rawFieldValue] = rawField.split(':').map(s => s.trim());
+
+    const fieldNameNoSpaces = rawFieldName.replace(/ /g, '');
+    const fieldName = fieldNameNoSpaces.charAt(0).toLowerCase() + fieldNameNoSpaces.slice(1);
+
+    const [value, unit] = rawFieldValue.split(' ');
+
+    if (unit == 'ms' || unit == 'MB') {
+        // value should be numeric
+        const numericValue = parseFloat(value);
+        return [fieldName + unit, numericValue] as [string, any];
+    } else {
+        // we didn't recognise the unit, perhaps there isn't one
+        return [fieldName, rawFieldValue] as [string, any];
+    }
+}
+
+function lambdaRequestLogData(line: string): StructuredLogData | undefined {
+    if (isRequestLogEntry(line)) {
+        const eventName = line.substr(0, line.indexOf(' '));
+        const requestId = fieldValue(line, 'RequestId:', 36);
+        const base = {
+            lambdaEvent: eventName,
+            lambdaRequestId: requestId
+        };
+        let stats: StructuredLogData = {};
+        switch(eventName) {
+            case 'END':
+                // no other fields
+                break;
+            case 'START':
+                // extract Version:
+                const version = fieldValue(line, 'Version:');
+                stats = {
+                    lambdaVersion: version
+                };
+                break;
+            case 'REPORT':
+                // extract other fields (conveniently tab separated)
+                const rawFields = line.split('\t').slice(1).map(s => s.trim()).filter(s => s.length > 0);
+                const fields: [string, any][] = rawFields.map(rawField => parseReportField(rawField));
+                stats = fields.reduce((acc: StructuredLogData, field) => {
+                    const [fieldName, fieldValue] = field;
+                    acc[fieldName] = fieldValue;
+                    return acc;
+                }, {});
+                break;
+        }
+
+        return Object.assign(base, {
+            lambdaStats: stats
+        });
+    } else {
+        return undefined;
+    }
+}
+
+function parseMessageJson(line: string): StructuredLogData {
+    try {
+        return JSON.parse(line.trim());
+    } catch (err) {
+        return {
+            'message': line.trim(),
+        };
+    }
+}
+
+// this parses a log line of the format <date>\t<requestId>\t<level>\t<message>
+function parseNodeLogFormat(logGroup: string, line: String): StructuredLogData | undefined {
+    const elements = line.split('\t');
+    const [dateString, lambdaRequestId, level, ...messageParts] = elements;
+    const isDate = !isNaN(Date.parse(dateString));
+    if (elements.length >= 4 && isDate) {
+        const message = messageParts.join('\t')
+        const structuredLog = parseMessageJson(message);
+        return {
+            // put level first so it can be overriden if structured log contains level
+            level,
+            ...structuredLog,
+            //timestamp: dateString, // this makes it explode for some reason
+            // put lambdaRequestId last so it can never be overwritten
+            lambdaRequestId,
+        }
+    }
+}
+
+// parse a log line
+function parseLambdaLogLine(logGroup: string, line: string): StructuredLogData {
+    const lambdaRequestLogDataFields = lambdaRequestLogData(line);
+    if (!!lambdaRequestLogDataFields) {
+        return Object.assign(lambdaRequestLogDataFields, {
+            'message': line,
+        });
+    }
+    // next see if this is the log line type we get from
+    const nodeLogData = parseNodeLogFormat(logGroup, line)
+    if (!!nodeLogData) {
+        return nodeLogData;
+    }
+    // fall back to normal parsing
+    return parseMessageJson(line);
+}
+
+export function createStructuredLog(logGroup: string, logStream: String, logEvent: CloudWatchLogsLogEvent, extraFields: StructuredFields): PublishableStructuredLogData {
+    const structuredLog = parseLambdaLogLine(logGroup, logEvent.message.trim());
+    const publishable: PublishableStructuredLogData =
+        Object.assign(structuredLog, {
+            '@timestamp': structuredLog.timestamp || new Date(logEvent.timestamp).toISOString(),
+            cloudwatchId: logEvent.id,
+            cloudwatchLogGroup: logGroup,
+            cloudwatchLogStream: logStream,
+        });
+    return Object.keys(extraFields)
+        .reduce((acc: PublishableStructuredLogData, key) => {
+            if (!!acc[key]) {
+                acc[`overwrittenFields.${key}`] = acc[key];
+            }
+            acc[key] = extraFields[key];
+            return acc;
+        }, publishable);
 }

--- a/src/logEntryProcessing.ts
+++ b/src/logEntryProcessing.ts
@@ -34,7 +34,9 @@ export function parseReportField(rawField: string): [string, any] {
 }
 
 export function lambdaRequestLogData(line: string): StructuredLogData | undefined {
-    if (isRequestLogEntry(line)) {
+    if (!isRequestLogEntry(line)) {
+        return undefined
+    } else {
         const eventName = line.substr(0, line.indexOf(' '));
         const requestId = fieldValue(line, 'RequestId', 36);
         const base = {
@@ -68,8 +70,6 @@ export function lambdaRequestLogData(line: string): StructuredLogData | undefine
         return Object.assign(base, {
             lambdaStats: stats
         });
-    } else {
-        return undefined;
     }
 }
 

--- a/src/logEntryProcessing.ts
+++ b/src/logEntryProcessing.ts
@@ -103,7 +103,7 @@ export function parseNodeLogFormat(logGroup: string, line: String): StructuredLo
 }
 
 // parse a log line
-function parseLambdaLogLine(logGroup: string, line: string): StructuredLogData {
+export function parseLambdaLogLine(logGroup: string, line: string): StructuredLogData {
     const lambdaRequestLogDataFields = lambdaRequestLogData(line);
     if (!!lambdaRequestLogDataFields) {
         return Object.assign(lambdaRequestLogDataFields, {

--- a/src/logEntryProcessing.ts
+++ b/src/logEntryProcessing.ts
@@ -7,7 +7,8 @@ export function isRequestLogEntry(line: string): boolean {
 }
 
 export function fieldValue(text: string, fieldNameText: string, valueLength?: number): string {
-    return text.substr(text.indexOf(fieldNameText)+fieldNameText.length, valueLength).trim();
+    const colonAndSpaceSeparator = 2;
+    return text.substr(text.indexOf(fieldNameText)+fieldNameText.length + colonAndSpaceSeparator, valueLength).trim();
 }
 
 /**
@@ -35,7 +36,7 @@ function parseReportField(rawField: string): [string, any] {
 function lambdaRequestLogData(line: string): StructuredLogData | undefined {
     if (isRequestLogEntry(line)) {
         const eventName = line.substr(0, line.indexOf(' '));
-        const requestId = fieldValue(line, 'RequestId:', 36);
+        const requestId = fieldValue(line, 'RequestId', 36);
         const base = {
             lambdaEvent: eventName,
             lambdaRequestId: requestId
@@ -47,7 +48,7 @@ function lambdaRequestLogData(line: string): StructuredLogData | undefined {
                 break;
             case 'START':
                 // extract Version:
-                const version = fieldValue(line, 'Version:');
+                const version = fieldValue(line, 'Version');
                 stats = {
                     lambdaVersion: version
                 };

--- a/src/shipLogEntries.ts
+++ b/src/shipLogEntries.ts
@@ -8,7 +8,7 @@ import { putKinesisRecords } from './kinesis';
 import { getStructuredFields } from './structuredFields';
 import { PutRecordsOutput } from 'aws-sdk/clients/kinesis';
 import { ConfigurationOptions } from 'aws-sdk/lib/config';
-import { isRequestLogEntry } from './logEntryProcessing';
+import { createStructuredLog } from './logEntryProcessing';
 
 const { awsConfig } = getCommonConfig();
 const { kinesisStreamName, kinesisStreamRole, structuredDataBucket, structuredDataKey } = getShipLogsConfig();
@@ -28,137 +28,6 @@ function getKinesisClient(awsConfig: ConfigurationOptions, role: string | undefi
     } else {
         return new Kinesis(awsConfig);
     }
-}
-
-function fieldValue(text: string, fieldNameText: string, valueLength?: number): string {
-    return text.substr(text.indexOf(fieldNameText)+fieldNameText.length, valueLength).trim();
-}
-
-/**
- * Parse an AWS lambda report field into a field name and a value
- * @param rawField The raw field that looks something like "Field Name: value unit"
- */
-function parseReportField(rawField: string): [string, any] {
-    const [rawFieldName, rawFieldValue] = rawField.split(':').map(s => s.trim());
-
-    const fieldNameNoSpaces = rawFieldName.replace(/ /g, '');
-    const fieldName = fieldNameNoSpaces.charAt(0).toLowerCase() + fieldNameNoSpaces.slice(1);
-
-    const [value, unit] = rawFieldValue.split(' ');
-
-    if (unit == 'ms' || unit == 'MB') {
-        // value should be numeric
-        const numericValue = parseFloat(value);
-        return [fieldName + unit, numericValue] as [string, any];
-    } else {
-        // we didn't recognise the unit, perhaps there isn't one
-        return [fieldName, rawFieldValue] as [string, any];
-    }
-}
-
-function lambdaRequestLogData(line: string): StructuredLogData | undefined {
-    if (isRequestLogEntry(line)) {
-        const eventName = line.substr(0, line.indexOf(' '));
-        const requestId = fieldValue(line, 'RequestId:', 36);
-        const base = {
-            lambdaEvent: eventName,
-            lambdaRequestId: requestId
-        };
-        let stats: StructuredLogData = {};
-        switch(eventName) {
-            case 'END':
-                // no other fields
-                break;
-            case 'START':
-                // extract Version:
-                const version = fieldValue(line, 'Version:');
-                stats = {
-                    lambdaVersion: version
-                };
-                break;
-            case 'REPORT':
-                // extract other fields (conveniently tab separated)
-                const rawFields = line.split('\t').slice(1).map(s => s.trim()).filter(s => s.length > 0);
-                const fields: [string, any][] = rawFields.map(rawField => parseReportField(rawField));
-                stats = fields.reduce((acc: StructuredLogData, field) => {
-                    const [fieldName, fieldValue] = field;
-                    acc[fieldName] = fieldValue;
-                    return acc;
-                }, {});
-                break;
-        }
-
-        return Object.assign(base, {
-            lambdaStats: stats
-        });
-    } else {
-        return undefined;
-    }
-}
-
-function parseMessageJson(line: string): StructuredLogData {
-    try {
-        return JSON.parse(line.trim());
-    } catch (err) {
-        return {
-            'message': line.trim(),
-        };
-    }
-}
-
-// this parses a log line of the format <date>\t<requestId>\t<level>\t<message>
-function parseNodeLogFormat(logGroup: string, line: String): StructuredLogData | undefined {
-    const elements = line.split('\t');
-    const [dateString, lambdaRequestId, level, ...messageParts] = elements;
-    const isDate = !isNaN(Date.parse(dateString));
-    if (elements.length >= 4 && isDate) {
-        const message = messageParts.join('\t')
-        const structuredLog = parseMessageJson(message);
-        return {
-            // put level first so it can be overriden if structured log contains level
-            level,
-            ...structuredLog,
-            //timestamp: dateString, // this makes it explode for some reason
-            // put lambdaRequestId last so it can never be overwritten
-            lambdaRequestId,
-        }
-    }
-}
-
-// parse a log line
-function parseLambdaLogLine(logGroup: string, line: string): StructuredLogData {
-    const lambdaRequestLogDataFields = lambdaRequestLogData(line);
-    if (!!lambdaRequestLogDataFields) {
-        return Object.assign(lambdaRequestLogDataFields, {
-            'message': line,
-        });
-    } 
-    // next see if this is the log line type we get from 
-    const nodeLogData = parseNodeLogFormat(logGroup, line)
-    if (!!nodeLogData) {
-        return nodeLogData;
-    }
-    // fall back to normal parsing
-    return parseMessageJson(line);
-}
-
-function createStructuredLog(logGroup: string, logStream: String, logEvent: CloudWatchLogsLogEvent, extraFields: StructuredFields): PublishableStructuredLogData {
-    const structuredLog = parseLambdaLogLine(logGroup, logEvent.message.trim());
-    const publishable: PublishableStructuredLogData = 
-        Object.assign(structuredLog, {
-            '@timestamp': structuredLog.timestamp || new Date(logEvent.timestamp).toISOString(),
-            cloudwatchId: logEvent.id,
-            cloudwatchLogGroup: logGroup,
-            cloudwatchLogStream: logStream,
-        });
-    return Object.keys(extraFields)
-        .reduce((acc: PublishableStructuredLogData, key) => {
-            if (!!acc[key]) {
-                acc[`overwrittenFields.${key}`] = acc[key];
-            }
-            acc[key] = extraFields[key];
-            return acc;
-        }, publishable);
 }
 
 export async function shipLogEntries(event: CloudWatchLogsEvent, context: Context): Promise<PutRecordsOutput[]> {


### PR DESCRIPTION
## What does this change?

This PR is a continuation of https://github.com/guardian/cloudwatch-logs-management/pull/42:

* Moves some more of the testable code into its own file
* Adds unit tests for several functions
* Fixes a small bug found during unit test implementation - we were dropping the last character of the request ID

You might find it easier to review this commit by commit, as this demonstrates where code has simply been moved vs where I've made minor modifications to fix the aforementioned bug.

## How to test

CI now runs these unit tests!

## How can we measure success?

It should be easier and safer to refactor this code in the future. We should feel more confident when performing upgrades etc.

## Have we considered potential risks?

I didn't write any of the original code, so there is a risk that I have misunderstood the intent behind some of the functions or assumed that expected results are correct when they are not.