### PR TITLE
Upgrade to TypeScript 4.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4666,9 +4666,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.9",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
-      "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
+      "integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==",
       "dev": true
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@types/node": "12.12.7",
     "jest": "^26.6.3",
     "ts-jest": "^26.5.3",
-    "typescript": "^3.9.9"
+    "typescript": "4.2.3"
   },
   "dependencies": {
     "aws-sdk": "^2.413.0"


### PR DESCRIPTION
## What does this change?

Brings the project up to date with the latest TypeScript version, as per https://github.com/guardian/cloudwatch-logs-management/pull/42#discussion_r595816224.

## How to test

Observe CI.

## How can we measure success?

The lambdas should continue to function normally.

## Have we considered potential risks?

Although this is a major version upgrade [`there are no major breaking changes`](https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/), so I think this is relatively low risk.