### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# See the documentation for all configuration options https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    commit-message:
+      prefix: "chore(deps): "


### PR DESCRIPTION
## What does this change?
This PR adds Dependabot to our repo in order to [help us to keep our dependencies up to date](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/). We are using Dependabot on a number of other Developer Experience-owned repos and it seems to be working well for us.

## How to test
Merge this, 🤞 and hope that Dependabot starts raising version bump PRs?

## How can we measure success?
It should be easier to keep our dependencies up to date.

## Have we considered potential risks?
I can't think of any; if this doesn't turn out to be useful we can easily switch it off again.