### PR TITLE
chore: Run Dependabot monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      # This repository does not run in a context that is accessible by users or external requests. Run Dependabot once a month to reduce the frequency of PRs.
+      interval: 'monthly'
     commit-message:
       prefix: "chore(deps): "


### PR DESCRIPTION
As this repository does not run in a context that is accessible to users or external requests, the risk of running old versions of dependencies for a short time is minimal. Update Dependabot's configuration to run monthly to reduce the frequency of PRs by a quarter and thus require less commitment from the team.