### PR TITLE
feat: Log the lambda's identity at start

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -12,7 +12,7 @@ import {
 } from "./config";
 import { updateStructuredFieldsData } from "./structuredFields";
 
-const { awsConfig } = getCommonConfig();
+const { awsConfig, identity } = getCommonConfig();
 
 const cloudwatchLogs = new CloudWatchLogs(awsConfig);
 const s3 = new S3(awsConfig);
@@ -25,6 +25,7 @@ function sleep(ms: number) {
 }
 
 export async function setRetention(): Promise<void> {
+  console.log(`setRetention lambda running in ${JSON.stringify(identity)}`);
   const { retentionInDays } = getSetRetentionConfig();
 
   const cloudwatchLogGroups = await getCloudWatchLogGroups(cloudwatchLogs);
@@ -65,6 +66,7 @@ function eligibleForLogShipping(
 }
 
 export async function setLogShipping(trigger: any): Promise<void> {
+  console.log(`setLogShipping lambda running in ${JSON.stringify(identity)}`);
   console.log("Configuring log shipping");
   console.log(JSON.stringify(trigger));
   const {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,14 @@
 import type { ConfigurationOptions } from "aws-sdk";
 
+interface Identity {
+  stack: string;
+  stage: string;
+  app: string;
+}
+
 interface CommonConfig {
   awsConfig: ConfigurationOptions;
+  identity: Identity;
 }
 
 interface SetRetentionConfig {
@@ -49,6 +56,11 @@ export function getCommonConfig(): CommonConfig {
     awsConfig: {
       region,
       maxRetries: maxRetries,
+    },
+    identity: {
+      stack: getRequiredEnv("STACK"),
+      stage: getRequiredEnv("STAGE"),
+      app: getRequiredEnv("APP"),
     },
   };
 }

--- a/src/shipLogEntries.ts
+++ b/src/shipLogEntries.ts
@@ -13,7 +13,7 @@ import { putKinesisRecords } from "./kinesis";
 import { createStructuredLog } from "./logEntryProcessing";
 import { getStructuredFields } from "./structuredFields";
 
-const { awsConfig } = getCommonConfig();
+const { awsConfig, identity } = getCommonConfig();
 const {
   kinesisStreamName,
   kinesisStreamRole,
@@ -45,6 +45,7 @@ export async function shipLogEntries(
   event: CloudWatchLogsEvent,
   context: Context
 ): Promise<PutRecordsOutput[]> {
+  console.log(`setLogShipping lambda running in ${JSON.stringify(identity)}`);
   const payload = Buffer.from(event.awslogs.data, "base64");
   const json = zlib.gunzipSync(payload).toString("utf8");
   const decoded: CloudWatchLogsDecodedData = JSON.parse(json);


### PR DESCRIPTION
## What does this change?

As a starter for making these lambdas stage aware (and thus allowing multiple instances to run in a single account/region), log out the identity of the lambda. This is primarily to ensure I understand the codebase - this change should be innocent enough to not be destructive 🤞🏽 .