### PR TITLE
Prevent ship log entries lambda from logging to CloudWatch

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -200,6 +200,19 @@ Resources:
               - s3:GetObject
             Resource: !Sub ${StructuredFieldsBucket.Arn}/*
 
+  DisableCloudWatchLoggingPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Deny
+            Action:
+              - logs:CreateLogGroup
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+            Resource: arn:aws:logs:*:*:*
+
   KinesisRoleAssumptionPolicy:
     Type: AWS::IAM::ManagedPolicy
     Condition: UseRoleAssumption
@@ -220,6 +233,13 @@ Resources:
       Handler: shipLogEntries.shipLogEntries
       Timeout: 5
       Policies:
+      # If this lambda accidentally subscribes to its own log group it can create a feedback loop which overwhelms
+      # Kinesis and spends huge amounts of $$$ on CloudWatch. There is some code which aims to filter out the relevant
+      # log group when creating subscriptions, but we also use this policy to prevent the lambda from sending log events
+      # by default, just to be on the safe side.
+      # If you need to view logs for debugging purposes, the policy below can be temporarily removed from a specific
+      # account using Riff-Raff
+      - !Ref DisableCloudWatchLoggingPolicy
       - !Ref ShipLogEntriesPolicy
       - Fn::If:
         - UseRoleAssumption

--- a/template.yaml
+++ b/template.yaml
@@ -201,7 +201,7 @@ Resources:
             Resource: !Sub ${StructuredFieldsBucket.Arn}/*
 
   DisableCloudWatchLoggingPolicy:
-    Type: AWS::IAM::Policy
+    Type: AWS::IAM::ManagedPolicy
     Properties:
       PolicyDocument:
         Version: 2012-10-17


### PR DESCRIPTION
## What does this change?

This PR prevents the ship log entries function from logging to CloudWatch in order to reduce the chances that we can accidentally create a feedback loop.

Unfortunately there is no easy way to turn off CloudWatch logging for a lambda so we have used [IAM permissions to achieve this goal](https://stackoverflow.com/a/53909607/15960596).

## How to test

We have [deployed this change](https://riffraff.gutools.co.uk/deployment/view/1a4da427-4a4b-482c-bf9e-5560dd874838) to the `deployTools` account (only) and confirmed that:

1. [CloudWatch logs for this lambda stop](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fdeploy-PROD-cloudwatch-logs-man-ShipLogEntriesFunc-GUUHQH6VZMM0/log-events$3Fstart$3D1635943500000$26end$3D1635948000000)
1. [Lambda logs for the account (which are forwarded by the ship log entries function) still appear in ELK](https://logs.gutools.co.uk/s/devx/goto/ba8841955732621ba72755d5854e3513)
1. Metrics for this lambda still look healthy:

![image](https://user-images.githubusercontent.com/19384074/140067783-f22859a8-14b6-4b12-9054-f6784a4abf67.png)

## How can we measure success?

Now that this lambda is unable to push its logs to CloudWatch, it should be impossible for us to spend huge amounts of money on CloudWatch via this lambda, regardless of how many versions are deployed within the same account or how many logs events they are processing.

## Have we considered potential risks?

This PR aims to mitigate the risk of creating a feedback loop, which should decrease the chances of repeating a [recent production incident](https://docs.google.com/document/d/1HNEo6UKQ-JhoXHp0mr-KuGC1Ra_8_BfwSuPq3VgO0AI/edit#heading=h.6g9t52rn8jyb).

However, by deploying this change we will impair our ability to debug production problems with this lambda. In the short term, we can temporarily enable logging for specific accounts if we need to (by commenting out some CFN). In the future a better solution would be to ship this lambda's logs directly to Kinesis.

On balance, I think that it is worth losing some visibility to improve safety here.