### PR TITLE
Support Auto Tagging ECS Tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Cloudwatch Logs Management
 This set of lambdas provides support to:
  - Set retention/expiry of cloudwatch log groups
  - Provide a lambda that forwards logs from lambdas to Kinesis ELK
- - Automatically seek out lambdas and configure log forwarding to ELK
+ - Automatically seek out lambdas and ECS task definitions and configure log forwarding to ELK
 
 Features
 --------

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,4 @@
-import { CloudWatchLogs, Lambda, S3 } from "aws-sdk";
+import { CloudWatchLogs, ECS, Lambda, S3 } from "aws-sdk";
 import {
   getCloudWatchLogGroups,
   setCloudwatchRetention,
@@ -17,6 +17,7 @@ const { awsConfig } = getCommonConfig();
 const cloudwatchLogs = new CloudWatchLogs(awsConfig);
 const s3 = new S3(awsConfig);
 const lambda = new Lambda(awsConfig);
+const ecs = new ECS(awsConfig);
 
 function sleep(ms: number) {
   return new Promise((resolve) => {
@@ -79,6 +80,7 @@ export async function setLogShipping(trigger: any): Promise<void> {
   await updateStructuredFieldsData(
     s3,
     lambda,
+    ecs,
     structuredDataBucket,
     structuredDataKey,
     optionLowerFirstCharOfTags

--- a/src/ecs.ts
+++ b/src/ecs.ts
@@ -1,5 +1,5 @@
-import { ECS } from "aws-sdk";
-import { Tag, TaskDefinition } from "aws-sdk/clients/ecs";
+import type { ECS } from "aws-sdk";
+import type { Tag, TaskDefinition } from "aws-sdk/clients/ecs";
 
 export interface TaskDefinitionWithTags {
   taskDefinition: TaskDefinition;

--- a/src/ecs.ts
+++ b/src/ecs.ts
@@ -1,0 +1,59 @@
+import { ECS } from "aws-sdk";
+import { Tag, TaskDefinition } from "aws-sdk/clients/ecs";
+
+export interface TaskDefinitionWithTags {
+  taskDefinition: TaskDefinition;
+  tags: Tags;
+}
+
+async function getAllTaskDefinitionArns(ecs: ECS): Promise<string[]> {
+  async function rec(acc: string[], token?: string): Promise<string[]> {
+    const result = await ecs
+      .listTaskDefinitions({
+        nextToken: token,
+      })
+      .promise();
+    const newAcc = acc.concat(result.taskDefinitionArns ?? []);
+    if (result.nextToken) {
+      return rec(newAcc, result.nextToken);
+    } else {
+      return newAcc;
+    }
+  }
+  return rec([]);
+}
+
+function convertTags(tags: Tag[]): Tags {
+  const tagsObject: Record<string, string> = {};
+  tags.forEach((t) => {
+    if (t.key && t.value) {
+      tagsObject[t.key] = t.value;
+    }
+  });
+  return tagsObject;
+}
+
+export async function getAllTaskDefinitions(
+  ecs: ECS
+): Promise<TaskDefinitionWithTags[]> {
+  const arns = await getAllTaskDefinitionArns(ecs);
+  const definitions = await Promise.all(
+    arns.map(async (arn) => {
+      const def = await ecs
+        .describeTaskDefinition({ taskDefinition: arn, include: ["TAGS"] })
+        .promise();
+      return def;
+    })
+  );
+
+  const withTags: TaskDefinitionWithTags[] = definitions
+    .filter((d) => d.taskDefinition)
+    .map((d) => {
+      return {
+        taskDefinition: d.taskDefinition,
+        tags: convertTags(d.tags ?? []),
+      };
+    }) as TaskDefinitionWithTags[];
+
+  return withTags;
+}

--- a/src/ecs.ts
+++ b/src/ecs.ts
@@ -39,10 +39,9 @@ export async function getAllTaskDefinitions(
   const arns = await getAllTaskDefinitionArns(ecs);
   const definitions = await Promise.all(
     arns.map(async (arn) => {
-      const def = await ecs
+      return await ecs
         .describeTaskDefinition({ taskDefinition: arn, include: ["TAGS"] })
         .promise();
-      return def;
     })
   );
 

--- a/src/structuredFields.ts
+++ b/src/structuredFields.ts
@@ -1,6 +1,5 @@
-import { ECS } from "aws-sdk";
+import type { ECS } from "aws-sdk";
 import type { Lambda, S3 } from "aws-sdk";
-import { log } from "util";
 import { getAllTaskDefinitions } from "./ecs";
 import { getLambdaFunctions } from "./lambda";
 import { getData, putData } from "./s3";

--- a/src/structuredFields.ts
+++ b/src/structuredFields.ts
@@ -1,4 +1,7 @@
+import { ECS } from "aws-sdk";
 import type { Lambda, S3 } from "aws-sdk";
+import { log } from "util";
+import { getAllTaskDefinitions } from "./ecs";
 import { getLambdaFunctions } from "./lambda";
 import { getData, putData } from "./s3";
 
@@ -22,13 +25,10 @@ function normalisedTags(tags: Tags, lowerFirstCharOfTag: boolean): Tags {
     );
 }
 
-export async function updateStructuredFieldsData(
-  s3: S3,
+async function lambdaLogGroupStructuredFields(
   lambda: Lambda,
-  bucket: string,
-  key: string,
   lowerFirstCharOfTag: boolean
-): Promise<void> {
+): Promise<LogGroupToStructuredFields> {
   // crawl all lambda functions
   const lambdaFunctions = await getLambdaFunctions(lambda);
   // convert into a data map
@@ -40,8 +40,50 @@ export async function updateStructuredFieldsData(
     },
     {}
   );
+  return dataMap;
+}
+
+async function ecsTaskLogGroupStructuredFields(
+  ecs: ECS,
+  lowerFirstCharOfTag: boolean
+): Promise<LogGroupToStructuredFields> {
+  const taskDefinitions = await getAllTaskDefinitions(ecs);
+  const dataMap = taskDefinitions.reduce(
+    (acc: LogGroupToStructuredFields, item) => {
+      const filteredTags = normalisedTags(item.tags, lowerFirstCharOfTag);
+      item.taskDefinition.containerDefinitions?.forEach((cd) => {
+        const logGroup = cd.logConfiguration?.options?.["awslogs-group"];
+        if (logGroup) {
+          acc[logGroup] = filteredTags;
+        }
+      });
+      return acc;
+    },
+    {}
+  );
+  return dataMap;
+}
+
+export async function updateStructuredFieldsData(
+  s3: S3,
+  lambda: Lambda,
+  ecs: ECS,
+  bucket: string,
+  key: string,
+  lowerFirstCharOfTag: boolean
+): Promise<void> {
+  const lambdaDataMap = await lambdaLogGroupStructuredFields(
+    lambda,
+    lowerFirstCharOfTag
+  );
+
+  const ecsDataMap = await ecsTaskLogGroupStructuredFields(
+    ecs,
+    lowerFirstCharOfTag
+  );
+
   // write out tag data to S3
-  const data = JSON.stringify(dataMap);
+  const data = JSON.stringify({ ...lambdaDataMap, ...ecsDataMap });
   console.log(`Putting new map into S3: ${data}`);
   await putData(s3, bucket, key, data);
 }

--- a/template.yaml
+++ b/template.yaml
@@ -154,6 +154,11 @@ Resources:
             Resource: '*'
           - Effect: Allow
             Action:
+              - ecs:ListTaskDefinitions
+              - ecs:DescribeTaskDefinition
+            Resource: '*'
+          - Effect: Allow
+            Action:
               - s3:PutObject
             Resource: !Sub ${StructuredFieldsBucket.Arn}/*
 


### PR DESCRIPTION
## What does this change?
On investigations we're making quite significant use of ECS tasks. These by default log to cloudwatch. By modifying the `ShippingPrefix` parameter of the investigations cloudwatch-logs-management stack we can get them into ELK, but without any tags. 

What this PR does is get the tagging to work - matching the tags on a task definition to the associated output log groups.

This is the functionality added by this PR - creating a map of loggroup:tags for all task definitions in the aws account. 

## What testing has been performed for this change?
Tested on investigations task definitions - you can see some logs [here](https://logs.gutools.co.uk/s/investigations/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-2h,to:now))&_a=(columns:!(message,app),filters:!(),index:'3501e690-a763-11eb-882c-5b432fbcaa69',interval:auto,query:(language:kuery,query:'app:%22ingest-land-registry%22'),sort:!()))

## How can we measure success?
Logs from task definitions are succesfully tagged
