### PR TITLE
Limit deployments to PROD

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -14,6 +14,9 @@ stacks:
 - targeting
 - pfi
 
+allowedStages:
+- PROD
+
 templates:
   lambda:
     type: aws-lambda


### PR DESCRIPTION
Previously we saw a large production incident when this project was deployed to an unsupported stage (CODE). This commit takes advantage of the new 'allowedStages' RiffRaff feature to ensure we do not deploy to CODE or other, non-PROD, stages again.

Note, there is currently a deploy restriction to CODE in RiffRaff already, so this adds extra defence on top of that.

![Screenshot 2022-05-23 at 14 45 37](https://user-images.githubusercontent.com/858402/169833504-30d31dac-c60f-4859-a940-80d268a3cee7.png)

