### PR TITLE
feat!: Remove ability to assume a role to write to kinesis

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -22,7 +22,6 @@ interface ConfigureLogShippingConfig extends StructuredDataConfig {
 
 interface ShipLogsConfig extends StructuredDataConfig {
 	kinesisStreamName: string;
-	kinesisStreamRole: string | undefined;
 }
 
 function getRequiredEnv(
@@ -82,11 +81,6 @@ export function getConfigureLogShippingConfig(): ConfigureLogShippingConfig {
 
 export function getShipLogsConfig(): ShipLogsConfig {
 	const kinesisStream = getRequiredEnv('LOG_KINESIS_STREAM');
-	const kinesisStreamRole = process.env['LOG_KINESIS_STREAM_ROLE'];
-	const maybeKinesisStreamRole =
-		!kinesisStreamRole || kinesisStreamRole.trim().length == 0
-			? undefined
-			: kinesisStreamRole;
 	const structuredDataBucket = getRequiredEnv('STRUCTURED_DATA_BUCKET');
 	const kinesisStreamName = kinesisStream.includes('/')
 		? kinesisStream.split('/')[1]
@@ -94,7 +88,6 @@ export function getShipLogsConfig(): ShipLogsConfig {
 
 	return {
 		kinesisStreamName,
-		kinesisStreamRole: maybeKinesisStreamRole,
 		structuredDataBucket,
 		structuredDataKey: 'structured-data.json',
 	};

--- a/template.yaml
+++ b/template.yaml
@@ -51,11 +51,6 @@ Parameters:
     Type: AWS::SSM::Parameter::Value<String>
     Default: /account/services/logging.stream
 
-  KinesisStreamRole:
-    Description: The ARN of the role to assume when writing to the kinesis stream (leaving this empty will mean no role is assumed)
-    Type: String
-    Default: ""
-
   CloudWatchLogsFilterName:
     Type: String
     Description: The name of the filter that should be added/maintained on log groups for shipping to the lambda
@@ -81,11 +76,6 @@ Globals:
     Environment:
       Variables:
         STAGE: !Ref Stage
-
-Conditions:
-  UseRoleAssumption:
-    Fn::Not:
-    - !Equals [ !Ref KinesisStreamRole, "" ]
 
 Resources:
   StructuredFieldsBucket:
@@ -218,17 +208,6 @@ Resources:
               - logs:PutLogEvents
             Resource: arn:aws:logs:*:*:*
 
-  KinesisRoleAssumptionPolicy:
-    Type: AWS::IAM::ManagedPolicy
-    Condition: UseRoleAssumption
-    Properties:
-      PolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Action: sts:assumeRole
-            Resource: !Ref KinesisStreamRole
-
   ShipLogEntriesFunc:
     Type: AWS::Serverless::Function
     Properties:
@@ -246,14 +225,9 @@ Resources:
       # account using Riff-Raff
       - !Ref DisableCloudWatchLoggingPolicy
       - !Ref ShipLogEntriesPolicy
-      - Fn::If:
-        - UseRoleAssumption
-        - !Ref KinesisRoleAssumptionPolicy
-        - !Ref AWS::NoValue
       Environment:
         Variables:
           LOG_KINESIS_STREAM: !Ref KinesisStreamArn
-          LOG_KINESIS_STREAM_ROLE: !Ref KinesisStreamRole
           STRUCTURED_DATA_BUCKET: !Ref StructuredFieldsBucket
       Tags:
         Stack: !Ref Stack


### PR DESCRIPTION
## What does this change?
<!-- 
A PR should have enough detail to be understandable far in the future. e.g 
What is the problem/why is the change needed? 
How does it solve it? 
Are there any questions or points of discussion?
Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. 
-->

Remove the optional `KinesisStreamRole` parameter from the CloudFormation template.

An analysis (see below) of instances of this stack show the following accounts have this set:
  - workflow
  - media-service
  - cmsFronts

These stacks belong to the Editorial Tools team (cc @guardian/digital-cms).

Only they have set the parameter because the logging setup within Editorial Tools was a little different from most. The team used to have a single logging stream that was shared between their various AWS accounts; apps that ran in a different account from the stream assumed a role to gain permission to write to it.

The team have since updated this, favouring a stream per account. This can be confirmed by observing the value of the `KinesisStreamArn` parameter - the value maps to a stream in the account.

<details>
<summary>Analysis performed</summary>

```sh
#!/usr/bin/env bash

set -e

REPOSITORY_NAME=guardian/cloudwatch-logs-management

# source from riff-raff.yaml and match it to Janus' naming of accounts
PROFILES=(
  composer
  workflow
  media-service
  capi
  cmsFronts
  ophan
  frontend
  identity
  mobile
  deployTools
  targeting
  investigations
)

for profile in "${PROFILES[@]}"; do
  aws cloudformation describe-stacks \
    --profile "$profile" \
    --region eu-west-1 \
    --no-paginate | \
    jq ".Stacks[] | select(.Tags[].Value == \"${REPOSITORY_NAME}\") | .Parameters"
done
```

</details>

This change is part of a migration to CDK. CDK tries to avoid CFN Parameters as they are first known at runtime, which is quite late. Instead it favours usage of "traditional" variables (i.e. `const role: string | undefined = "asdf"`). By removing this parameter, the migration process becomes easier.

## What testing has been performed for this change?
<!-- 
Due to the nature of this project, there is no pre-production environment available for testing changes. Consequently, we recommend using Riff-Raff to deploy 
your branch to an individual account (rather than all accounts, which is the default!) in order to validate your changes in production. 

In order to do this, select `Preview` from the deployment page (instead of `Deploy Now`). 
Next `Deselect all` and then manually select all deployment tasks for a specific account. 
Once you’ve done this you can `Preview with selections`, check the list of tasks and then `Deploy`. 
-->

As this stack is a singleton, testing can only be performed by deploying to PROD. Logs should continue to land in Central ELK.

## How can we measure success?
<!-- 
Do you expect errors to decrease, or performance to improve? 
What can be used to prove this? A filtered view of logs or analytics, etc? 
-->

Simpler CloudFormation, and application code.

## Have we considered potential risks?
<!-- 
What are the potential risks and how can they be mitigated?
Does the change add or remove a feature, significantly alter AWS resources or introduce some other form of risk? 
If so, you might also want to inform the teams who own the affected AWS accounts via Chat/email so they can keep an eye out for any problems. 
-->

Should the above assertions be incorrect, lambda logs in the accounts will not be shipped to Central ELK and teams would have to view them with CloudWatch Logs. I don't think this is a blocker though as logs won't be lost, just in a different place. Should this happen, we'd fix forward.