### PR TITLE
feat: Add build info markers to log lines

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -34,6 +34,11 @@ nvm use
 npm ci
 npm run test
 npm run lint
+
+COMMIT=$(git rev-parse HEAD)
+BUILD="${BUILD_NUMBER:-DEV}"
+echo "export const BUILD_INFO = { 'ShippedBy-revision': '${COMMIT}', 'ShippedBy-buildNumber': '${BUILD}' };"  > src/build-info.ts
+
 npm run build
 set -x
 # bundle lambda code

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -1,0 +1,10 @@
+/**
+ * Basic build info to help identify what version of the app is running.
+ * This file will be re-generated in CI with real values.
+ *
+ * @see ../scripts/ci.sh
+ */
+export const BUILD_INFO = {
+	'ShippedBy-revision': 'DEV',
+	'ShippedBy-buildNumber': 'DEV',
+};

--- a/src/shipLogEntries.ts
+++ b/src/shipLogEntries.ts
@@ -6,6 +6,7 @@ import type {
 } from 'aws-lambda';
 import { Kinesis, S3 } from 'aws-sdk';
 import type { PutRecordsOutput } from 'aws-sdk/clients/kinesis';
+import { BUILD_INFO } from './build-info';
 import { getCommonConfig, getShipLogsConfig } from './config';
 import { putKinesisRecords } from './kinesis';
 import { createStructuredLog } from './logEntryProcessing';
@@ -42,12 +43,11 @@ export async function shipLogEntries(
 		return {};
 	});
 	const structuredLogs = decoded.logEvents.map((logEvent) => {
-		return createStructuredLog(
-			logGroup,
-			decoded.logStream,
-			logEvent,
-			extraFields,
-		);
+		return createStructuredLog(logGroup, decoded.logStream, logEvent, {
+			...extraFields,
+			...BUILD_INFO,
+			ShippedBy: 'cloudwatch-logs-management', // casing matches https://github.com/guardian/devx-logs
+		});
 	});
 	console.log(
 		`Sending ${structuredLogs.length} events from ${logGroup} to ${kinesisStreamName})`,


### PR DESCRIPTION
## What does this change?
<!-- 
A PR should have enough detail to be understandable far in the future. e.g 
What is the problem/why is the change needed? 
How does it solve it? 
Are there any questions or points of discussion?
Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. 
-->

Further augment the log message in Central ELK with information about the version of this app. This will help with debugging.

Inspired by [tools-index](https://github.com/guardian/tools-index/blob/1543179dab10d0ce1f3f1280405cf3bdf26046b0/.github/workflows/ci.yml#L47).

An alternative to this could be to add this information as tags in AWS. However, this would mean each deployment of this app would incur the cost of a CloudFormation deployment, even if no code changes to the infrastructure were made. See also: https://github.com/guardian/cdk/pull/1244.

## What testing has been performed for this change?
<!-- 
Due to the nature of this project, there is no pre-production environment available for testing changes. Consequently, we recommend using Riff-Raff to deploy 
your branch to an individual account (rather than all accounts, which is the default!) in order to validate your changes in production. 

In order to do this, select `Preview` from the deployment page (instead of `Deploy Now`). 
Next `Deselect all` and then manually select all deployment tasks for a specific account. 
Once you’ve done this you can `Preview with selections`, check the list of tasks and then `Deploy`. 
-->

I've deployed this to the DevX account and can see the new log markers appearing:

![image](https://user-images.githubusercontent.com/836140/175308584-e109b2e9-e2ce-4c5a-a167-7fc9a15930f7.png)

## How can we measure success?
<!-- 
Do you expect errors to decrease, or performance to improve? 
What can be used to prove this? A filtered view of logs or analytics, etc? 
-->

It's easier to debug changes to this application.

## Have we considered potential risks?
<!-- 
What are the potential risks and how can they be mitigated?
Does the change add or remove a feature, significantly alter AWS resources or introduce some other form of risk? 
If so, you might also want to inform the teams who own the affected AWS accounts via Chat/email so they can keep an eye out for any problems. 
-->

There's a risk that future changes to `build-info.ts` are not reflected in `ci.sh`. Hopefully the inline comment mitigates against that.