### PR TITLE
feat!: Remove redundant `OptionLowerFirstCharOfTags` CFN parameter

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -74,7 +74,6 @@ export async function setLogShipping(trigger: unknown): Promise<void> {
 		logShippingLambdaArn,
 		structuredDataBucket,
 		structuredDataKey,
-		optionLowerFirstCharOfTags,
 	} = getConfigureLogShippingConfig();
 
 	await updateStructuredFieldsData(
@@ -83,7 +82,6 @@ export async function setLogShipping(trigger: unknown): Promise<void> {
 		ecs,
 		structuredDataBucket,
 		structuredDataKey,
-		optionLowerFirstCharOfTags,
 	);
 
 	const logShippingLambdaName = logShippingLambdaArn.split(':')[6];

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,7 +17,6 @@ interface ConfigureLogShippingConfig extends StructuredDataConfig {
 	logNamePrefixes: string[];
 	logShippingFilterName: string;
 	logShippingLambdaArn: string;
-	optionLowerFirstCharOfTags: boolean;
 }
 
 interface ShipLogsConfig extends StructuredDataConfig {
@@ -66,8 +65,6 @@ export function getConfigureLogShippingConfig(): ConfigureLogShippingConfig {
 	const logShippingFilterName = getRequiredEnv('LOG_SHIPPING_FILTER_NAME');
 	const logShippingLambdaArn = getRequiredEnv('LOG_SHIPPING_LAMBDA_ARN');
 	const structuredDataBucket = getRequiredEnv('STRUCTURED_DATA_BUCKET');
-	const optionLowerFirstCharOfTags =
-		getRequiredEnv('OPTION_LOWER_FIRST_CHAR_OF_TAGS') === 'true';
 
 	return {
 		logNamePrefixes,
@@ -75,7 +72,6 @@ export function getConfigureLogShippingConfig(): ConfigureLogShippingConfig {
 		logShippingLambdaArn,
 		structuredDataBucket,
 		structuredDataKey: 'structured-data.json',
-		optionLowerFirstCharOfTags,
 	};
 }
 

--- a/template.yaml
+++ b/template.yaml
@@ -56,14 +56,6 @@ Parameters:
     Description: The name of the filter that should be added/maintained on log groups for shipping to the lambda
     Default: GuLogShippingLambdaFilter
 
-  OptionLowerFirstCharOfTags:
-    Type: String
-    Description: Whether to make the first character of tags from lambdas lower case or not (this can help to align tags with other infrastructure in ELK)
-    AllowedValues:
-    - true
-    - false
-    Default: true
-
   DistBucket:
     Description: The S3 bucket for distributing code in this account
     Type: AWS::SSM::Parameter::Value<String>
@@ -168,7 +160,6 @@ Resources:
           LOG_NAME_PREFIXES: !Join [",", !Ref ShippingPrefix]
           LOG_SHIPPING_FILTER_NAME: !Ref CloudWatchLogsFilterName
           STRUCTURED_DATA_BUCKET: !Ref StructuredFieldsBucket
-          OPTION_LOWER_FIRST_CHAR_OF_TAGS: !Ref OptionLowerFirstCharOfTags
       Events:
         # Update every 10 mins
         CheckStatusEvent:


### PR DESCRIPTION
## What does this change?
<!-- 
A PR should have enough detail to be understandable far in the future. e.g 
What is the problem/why is the change needed? 
How does it solve it? 
Are there any questions or points of discussion?
Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. 
-->

As no instance of this stack sets this value to `false`, we can remove it and simplify the app. This is done for similar purposes to #153, namely to make a CDK migration easier.

## What testing has been performed for this change?
<!-- 
Due to the nature of this project, there is no pre-production environment available for testing changes. Consequently, we recommend using Riff-Raff to deploy 
your branch to an individual account (rather than all accounts, which is the default!) in order to validate your changes in production. 

In order to do this, select `Preview` from the deployment page (instead of `Deploy Now`). 
Next `Deselect all` and then manually select all deployment tasks for a specific account. 
Once you’ve done this you can `Preview with selections`, check the list of tasks and then `Deploy`. 
-->

I've checked each instance of this application and confirmed they all have `OptionLowerFirstCharOfTags` set to `true`.

## How can we measure success?
<!-- 
Do you expect errors to decrease, or performance to improve? 
What can be used to prove this? A filtered view of logs or analytics, etc? 
-->

Less code!

## Have we considered potential risks?
<!-- 
What are the potential risks and how can they be mitigated?
Does the change add or remove a feature, significantly alter AWS resources or introduce some other form of risk? 
If so, you might also want to inform the teams who own the affected AWS accounts via Chat/email so they can keep an eye out for any problems. 
-->

I can't work out why one would set this parameter to false (it was added as part of the [initial commit](https://github.com/guardian/cloudwatch-logs-management/commit/f03df0b3e5c44d76ffcf9f38edbf6fff972b5556#diff-1363ef5ce8886100842332c97163aad7934237e1fe49b5d40422b45fdc30f38eR33)). That is, we might break some workflow.
