### PR TITLE
chore: Tune Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,10 @@ updates:
       interval: 'monthly'
     commit-message:
       prefix: "chore(deps): "
+    
+    # The version of AWS CDK libraries must match those from @guardian/cdk.
+    # We'd never be able to update them here independently, so just ignore them.
+    ignore:
+      - dependency-name: "aws-cdk"
+      - dependency-name: "aws-cdk-lib"
+      - dependency-name: "constructs"


### PR DESCRIPTION
The version of AWS CDK libraries must match those from @guardian/cdk. We'd never be able to update them here independently, so just ignore them.

---

Closes #188.
Closes #191.