### PR TITLE
refactor: Simplify retry config

### DIFF
--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -42,11 +42,11 @@ function getRequiredEnv(
 
 export function getCommonConfig(): CommonConfig {
 	const region = getRequiredEnv('AWS_REGION');
-	const maxRetries = parseInt(getRequiredEnv('AWS_RETRIES', '10'));
+	const maxRetries = 10;
 	return {
 		awsConfig: {
 			region,
-			maxRetries: maxRetries,
+			maxRetries,
 		},
 	};
 }


### PR DESCRIPTION
## What does this change?
<!-- 
A PR should have enough detail to be understandable far in the future. e.g 
What is the problem/why is the change needed? 
How does it solve it? 
Are there any questions or points of discussion?
Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. 
-->

Currently we configure AWS retries by reading the `AWS_RETRIES` env var, defaulting to `10`. `AWS_RETRIES` is not a [runtime environment variable](https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime), and we're not explicitly setting it. That is, we always hit the fallback value.

In this change, we simplify this by just setting retries explicitly to 10.

## What testing has been performed for this change?
<!-- 
Due to the nature of this project, there is no pre-production environment available for testing changes. Consequently, we recommend using Riff-Raff to deploy 
your branch to an individual account (rather than all accounts, which is the default!) in order to validate your changes in production. 

In order to do this, select `Preview` from the deployment page (instead of `Deploy Now`). 
Next `Deselect all` and then manually select all deployment tasks for a specific account. 
Once you’ve done this you can `Preview with selections`, check the list of tasks and then `Deploy`. 
-->

n/a

## How can we measure success?
<!-- 
Do you expect errors to decrease, or performance to improve? 
What can be used to prove this? A filtered view of logs or analytics, etc? 
-->

n/a

## Have we considered potential risks?
<!-- 
What are the potential risks and how can they be mitigated?
Does the change add or remove a feature, significantly alter AWS resources or introduce some other form of risk? 
If so, you might also want to inform the teams who own the affected AWS accounts via Chat/email so they can keep an eye out for any problems. 
-->

n/a