### PR TITLE
ci: Move CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+on:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  CI:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+      # Setup AWS credentials to enable uploading to S3 for Riff-Raff.
+      # See https://github.com/aws-actions/configure-aws-credentials
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          aws-region: eu-west-1
+      - run: |
+          LAST_TEAMCITY_BUILD=488
+          export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
+          ./scripts/ci.sh

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -5,25 +5,13 @@ set -e
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 ROOT_DIR="${DIR}/.."
 
-setupNodeVersion() {
-  # source NVM on teamcity
-  if [ -e "${NVM_DIR}/nvm.sh" ]; then
-      . ${NVM_DIR}/nvm.sh
-  else
-      . $(brew --prefix nvm)/nvm.sh
-  fi
-  nvm install
-  nvm use
-}
-
 injectBuildInfo() {
   COMMIT=$(git rev-parse HEAD)
-  BUILD="${BUILD_NUMBER:-DEV}"
+  BUILD="${GITHUB_RUN_NUMBER:-DEV}"
   echo "// prettier-ignore" > "${ROOT_DIR}/packages/app/src/build-info.ts"
   echo "export const BUILD_INFO = { 'ShippedBy-revision': '${COMMIT}', 'ShippedBy-buildNumber': '${BUILD}' };" >> "${ROOT_DIR}/packages/app/src/build-info.ts"
 }
 
-setupNodeVersion
 injectBuildInfo
 
 npm ci


### PR DESCRIPTION
## What does this change?
<!-- 
A PR should have enough detail to be understandable far in the future. e.g 
What is the problem/why is the change needed? 
How does it solve it? 
Are there any questions or points of discussion?
Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. 
-->

Move CI providers from TeamCity to GitHub Actions. This is mainly driven by #209 not building in TeamCity due to TeamCity failing to run Node 18.

Initially keeping the CI steps the same as TeamCity's, that is using the NPM module `@guardian/node-riffraff-artifact`. We can move to `guardian/actions-riff-raff` separately.

> **Note**
> The branch protection rules on the repo are configured to require TeamCity to pass, however I've paused the builds there. Once approved, I'll update the branch protection rules.

## What testing has been performed for this change?
<!-- 
Due to the nature of this project, there is no pre-production environment available for testing changes. Consequently, we recommend using Riff-Raff to deploy 
your branch to an individual account (rather than all accounts, which is the default!) in order to validate your changes in production. 

In order to do this, select `Preview` from the deployment page (instead of `Deploy Now`). 
Next `Deselect all` and then manually select all deployment tasks for a specific account. 
Once you’ve done this you can `Preview with selections`, check the list of tasks and then `Deploy`. 
-->

Observation of the artifacts in Riff-Raff:
  - [`main`](https://riffraff.gutools.co.uk/deployment/request/deployFiles?projectName=tools%3A%3Acloudwatch-logs-management&id=488)
  - [this branch](https://riffraff.gutools.co.uk/deployment/request/deployFiles?projectName=tools%3A%3Acloudwatch-logs-management&id=491)

The `cloudwatch-logs-management.zip` file is the same size (well, this branch is bigger by one byte), demonstrating this is a no-op.

## How can we measure success?
<!-- 
Do you expect errors to decrease, or performance to improve? 
What can be used to prove this? A filtered view of logs or analytics, etc? 
-->

Ideally this should be a no-op!

## Have we considered potential risks?
<!-- 
What are the potential risks and how can they be mitigated?
Does the change add or remove a feature, significantly alter AWS resources or introduce some other form of risk? 
If so, you might also want to inform the teams who own the affected AWS accounts via Chat/email so they can keep an eye out for any problems. 
-->

n/a