### PR TITLE
ci: Run CI when `main` is updated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 on:
   pull_request:
   workflow_dispatch:
+  push:
+    branches:
+      - main
 jobs:
   CI:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What does this change?
<!-- 
A PR should have enough detail to be understandable far in the future. e.g 
What is the problem/why is the change needed? 
How does it solve it? 
Are there any questions or points of discussion?
Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. 
-->

Create a build when `main` is pushed to (i.e. on merge), so that CD is triggered. This was missed in https://github.com/guardian/cloudwatch-logs-management/pull/211.
