### PR TITLE
Update targeting AWS account log retention config

### DIFF
--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -20,10 +20,10 @@ export const stacks: CloudwatchLogsManagementProps[] = [
 	{
 		stack: 'targeting',
 		logShippingPrefixes: [
-			'/aws/lambda/diff-checker-PROD',
-			'/aws/lambda/diff-publisher-PROD',
-			'/aws/lambda/braze-exporter-trigger-PROD',
-			'/aws/lambda/braze-exporter-callback-PROD',
+			'/aws/lambda/diff-checker',
+			'/aws/lambda/diff-publisher',
+			'/aws/lambda/braze-exporter-trigger',
+			'/aws/lambda/braze-exporter-callback',
 		],
 	},
 	{

--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -24,6 +24,8 @@ export const stacks: CloudwatchLogsManagementProps[] = [
 			'/aws/lambda/diff-publisher',
 			'/aws/lambda/braze-exporter-trigger',
 			'/aws/lambda/braze-exporter-callback',
+			'/aws/lambda/braze-exporter-progress',
+			'/aws/lambda/braze-exporter-bigquery-ingest',
 		],
 	},
 	{


### PR DESCRIPTION
## What does this change?

Updates the list of prefixes of log groups in the targeting account which we want to apply log retention policies to:

a) Remove the stage suffix so that CODE log groups have the policy applied
b) Add a couple of lambdas which were missing from the list

## What testing has been performed for this change?
<!-- 
Due to the nature of this project, there is no pre-production environment available for testing changes. Consequently, we recommend using Riff-Raff to deploy 
your branch to an individual account (rather than all accounts, which is the default!) in order to validate your changes in production. 

In order to do this, select `Preview` from the deployment page (instead of `Deploy Now`). 
Next `Deselect all` and then manually select all deployment tasks for a specific account. 
Once you’ve done this you can `Preview with selections`, check the list of tasks and then `Deploy`. 
-->

## How can we measure success?
<!-- 
Do you expect errors to decrease, or performance to improve? 
What can be used to prove this? A filtered view of logs or analytics, etc? 
-->

## Have we considered potential risks?
<!-- 
What are the potential risks and how can they be mitigated?
Does the change add or remove a feature, significantly alter AWS resources or introduce some other form of risk? 
If so, you might also want to inform the teams who own the affected AWS accounts via Chat/email so they can keep an eye out for any problems. 
-->
