### PR TITLE
Move config fetching into lambda handlers

### DIFF
--- a/packages/app/src/handlers/set-log-shipping.ts
+++ b/packages/app/src/handlers/set-log-shipping.ts
@@ -7,13 +7,6 @@ import {
 import { getCommonConfig, getConfigureLogShippingConfig } from '../config';
 import { updateStructuredFieldsData } from '../structuredFields';
 
-const { awsConfig } = getCommonConfig();
-
-const cloudwatchLogs = new CloudWatchLogs(awsConfig);
-const s3 = new S3(awsConfig);
-const lambda = new Lambda(awsConfig);
-const ecs = new ECS(awsConfig);
-
 function eligibleForLogShipping(
 	logNamePrefixes: string[],
 	groupName: string,
@@ -27,6 +20,13 @@ function eligibleForLogShipping(
 }
 
 export async function setLogShipping(trigger: unknown): Promise<void> {
+	const { awsConfig } = getCommonConfig();
+
+	const cloudwatchLogs = new CloudWatchLogs(awsConfig);
+	const s3 = new S3(awsConfig);
+	const lambda = new Lambda(awsConfig);
+	const ecs = new ECS(awsConfig);
+
 	console.log('Configuring log shipping');
 	console.log(JSON.stringify(trigger));
 	const {

--- a/packages/app/src/handlers/set-retention.ts
+++ b/packages/app/src/handlers/set-retention.ts
@@ -2,9 +2,6 @@ import { CloudWatchLogs } from 'aws-sdk';
 import { getCloudWatchLogGroups, setCloudwatchRetention } from '../cloudwatch';
 import { getCommonConfig, getSetRetentionConfig } from '../config';
 
-const { awsConfig } = getCommonConfig();
-const cloudwatchLogs = new CloudWatchLogs(awsConfig);
-
 function sleep(ms: number) {
 	return new Promise((resolve) => {
 		setTimeout(resolve, ms);
@@ -12,6 +9,9 @@ function sleep(ms: number) {
 }
 
 export async function setRetention(): Promise<void> {
+	const { awsConfig } = getCommonConfig();
+	const cloudwatchLogs = new CloudWatchLogs(awsConfig);
+
 	const { retentionInDays } = getSetRetentionConfig();
 	const cloudwatchLogGroups = await getCloudWatchLogGroups(cloudwatchLogs);
 

--- a/packages/app/src/handlers/ship-log-entries.ts
+++ b/packages/app/src/handlers/ship-log-entries.ts
@@ -13,17 +13,17 @@ import { createStructuredLog } from '../logEntryProcessing';
 import type { StructuredFields } from '../model';
 import { getStructuredFields } from '../structuredFields';
 
-const { awsConfig } = getCommonConfig();
-const { kinesisStreamName, structuredDataBucket, structuredDataKey } =
-	getShipLogsConfig();
-
-const s3 = new S3(awsConfig);
-const kinesis = new Kinesis(awsConfig);
-
 export async function shipLogEntries(
 	event: CloudWatchLogsEvent,
 	context: Context,
 ): Promise<PutRecordsOutput[]> {
+	const { awsConfig } = getCommonConfig();
+	const { kinesisStreamName, structuredDataBucket, structuredDataKey } =
+		getShipLogsConfig();
+
+	const s3 = new S3(awsConfig);
+	const kinesis = new Kinesis(awsConfig);
+
 	const payload = Buffer.from(event.awslogs.data, 'base64');
 	const json = zlib.gunzipSync(payload).toString('utf8');
 	const decoded = JSON.parse(json) as CloudWatchLogsDecodedData;


### PR DESCRIPTION
## What does this change?

This PR moves the config fetching (from the env) to the relevant lambda handlers. Before config was fetched at the top level of each of the files which define the lambda handlers. This means that the config was fetched when the file was included, even if the handler wasn't run. So when running the set-retention lambda, for example, we were seeing errors because the config for the ship-log-entries lambda wasn't available.

## What testing has been performed for this change?
<!-- 
Due to the nature of this project, there is no pre-production environment available for testing changes. Consequently, we recommend using Riff-Raff to deploy 
your branch to an individual account (rather than all accounts, which is the default!) in order to validate your changes in production. 

In order to do this, select `Preview` from the deployment page (instead of `Deploy Now`). 
Next `Deselect all` and then manually select all deployment tasks for a specific account. 
Once you’ve done this you can `Preview with selections`, check the list of tasks and then `Deploy`. 
-->

## How can we measure success?
<!-- 
Do you expect errors to decrease, or performance to improve? 
What can be used to prove this? A filtered view of logs or analytics, etc? 
-->

## Have we considered potential risks?
<!-- 
What are the potential risks and how can they be mitigated?
Does the change add or remove a feature, significantly alter AWS resources or introduce some other form of risk? 
If so, you might also want to inform the teams who own the affected AWS accounts via Chat/email so they can keep an eye out for any problems. 
-->
