### PR TITLE
Add Personalisation AWS account

### DIFF
--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -18,6 +18,7 @@ export const stacks: CloudwatchLogsManagementProps[] = [
 	{ stack: 'identity' },
 	{ stack: 'mobile' },
 	{ stack: 'security' },
+	{ stack: 'personalisation' },
 	{
 		stack: 'targeting',
 		logShippingPrefixes: [


### PR DESCRIPTION
## What does this change?

We would like to set log retention and log shipping to a new Personalisation account. 