### PR TITLE
feat: Provision this service into the Playground account

### DIFF
--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -38,6 +38,7 @@ export const stacks: CloudwatchLogsManagementProps[] = [
 			'lurch',
 		],
 	},
+	{ stack: 'playground' },
 ];
 
 stacks.forEach((stack) => new CloudwatchLogsManagement(app, stack));


### PR DESCRIPTION
## What does this change?
We have a few experimental lambdas in the Playground account, and it'll be nice to observe their logs in Central ELK.

## What testing has been performed for this change?
I've [deployed](https://riffraff.gutools.co.uk/deployment/view/a83ea275-1a7d-4d92-87b8-c60bc6f130fe) this, triggered a [lambda](https://github.com/guardian/examples/tree/example-typescript-lambda), and found it's [logs in Central ELK](https://logs.gutools.co.uk/goto/ea4e3010-5145-11ee-913c-1f0e93d001da) (might need to expand the time frame).

## How can we measure success?
Logs for lambdas in the Playground account will appear in Central ELK, and their CloudWatch log groups' retention period is set to 14 days.

## Have we considered potential risks?
N/A.