### PR TITLE
fix: Parsing of structured fields from S3

### DIFF
--- a/packages/app/src/s3.ts
+++ b/packages/app/src/s3.ts
@@ -27,7 +27,7 @@ export async function getData(
 	});
 	const result = await s3.send(command);
 	if (result.Body) {
-		return result.Body.toString();
+		return result.Body.transformToString();
 	} else {
 		return Promise.reject(`Value at s3://${bucket}/${key} could not be found`);
 	}


### PR DESCRIPTION
## What does this change?

Switch the method used to retrieve the string contents of the `structured-fields.json` file from `toString()` to `transformToString()`.

After #276 was merged, we move from using v2 to v3 of the AWS SDK. However, in v3 of the SDK the `toString` method called on an S3 response body no longer returns the body, but instead just `[Object] object` ([see this comment for some more context](https://github.com/aws/aws-sdk-js-v3/issues/1877#issuecomment-1287263428)). This causes `JSON.parse` to throw an error, which prevents the structured fields stored on S3 from being included as fields in ELK. This error is handled in one of the calling functions, so logs are still shipped to S3, just without the fields.

## What testing has been performed for this change?

I deployed this change to the developer playground account, and re-enabled Cloudwatch logging for the log shipping lambda. It was then possible to check the structured fields JSON was being successfully parsed, and tags started appearing as fields in ELK:

![Screenshot 2024-01-18 at 16 06 02](https://github.com/guardian/cloudwatch-logs-management/assets/8000415/1c17e9a6-cd43-4912-829b-6c3cdacb7242)

_^ Presence of the stage tag, as an example._


## How can we measure success?

Tags applied to lambdas and ECS tasks should re-appear as fields in ELK.
