### PR TITLE
chore(dependabot): Add group configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,14 @@ updates:
       - dependency-name: "aws-cdk"
       - dependency-name: "aws-cdk-lib"
       - dependency-name: "constructs"
+
+    groups:
+      aws-sdk:
+        patterns:
+          - "@aws-sdk/*"
+      code-quality:
+        patterns:
+          - "@guardian/eslint-config-typescript"
+          - "@guardian/prettier"
+          - "eslint"
+          - "eslint-plugin-prettier"


### PR DESCRIPTION
## What does this change?
Create groups to update the AWS SDK, and code quality tools.

This should reduce the number of PRs. These would become one:
<img width="819" alt="image" src="https://github.com/guardian/cloudwatch-logs-management/assets/836140/8c1ff198-bcba-4289-82f1-cb330a4d9223">