### PR TITLE
Add investigations stack to cloudwatch-logs-management

### DIFF
--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -29,12 +29,6 @@ export const stacks: CloudwatchLogsManagementProps[] = [
 		],
 	},
 	{
-		stack: 'investigations',
-		logShippingPrefixes: [
-			'/aws/lambda/transcription-service',
-		],
-	},
-	{
 		stack: 'pfi',
 		logShippingPrefixes: [
 			'/aws/lambda/lurch',
@@ -42,6 +36,7 @@ export const stacks: CloudwatchLogsManagementProps[] = [
 			'/aws/lambda/pfi-lurch',
 			'fb-ad-library',
 			'lurch',
+			'/aws/lambda/transcription-service',
 		],
 	},
 	{ stack: 'playground' },


### PR DESCRIPTION
## What does this change?
The investigations account is currently working on a an allowlist approach to sending logs to central ELK for security reasons - we don't want the logs for all our services visible by everyone in the department.

This change adds configuration so that logs from our [new transcription-service](https://github.com/guardian/transcription-service) lambdas are sent to central ELK.

## What testing has been performed for this change?
I'm not sure, I'm hoping maybe none required