### PR TITLE
add aws transfer to media service log shipping prefixes

### DIFF
--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -10,7 +10,12 @@ export const stacks: CloudwatchLogsManagementProps[] = [
 	{ stack: 'deploy' },
 	{ stack: 'flexible' },
 	{ stack: 'workflow' },
-	{ stack: 'media-service' },
+	{ stack: 'media-service',
+		logShippingPrefixes: [
+			'/aws/lambda',
+			'/aws/transfer'
+		],
+	},
 	{ stack: 'content-api' },
 	{ stack: 'cms-fronts' },
 	{ stack: 'ophan' },


### PR DESCRIPTION
## What does this change?

Content Production are migrating FTP clients to a managed SFTP service using AWS Transfer. At present, the logs for this are not shipped to central ELK, which complicates troubleshooting.

This PR adds the AWS transfer prefix (as well as the existing Lambda one) to the Media Service account to enable shipping of logs

## What testing has been performed for this change?

Tested in Media Service Account - logs now visible in Central ELK

## How can we measure success?

Transfer logs should be available in central ELK

## Have we considered potential risks?

SHould be fine