### PR TITLE
Process CloudWatch Logs produced by CloudTrail for deploy stack (DevX account)

### DIFF
--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -1,5 +1,5 @@
 import 'source-map-support/register';
-import { GuRoot } from "@guardian/cdk/lib/constructs/root";
+import { GuRoot } from '@guardian/cdk/lib/constructs/root';
 import type { CloudwatchLogsManagementProps } from '../lib/cloudwatch-logs-management';
 import { CloudwatchLogsManagement } from '../lib/cloudwatch-logs-management';
 
@@ -7,14 +7,12 @@ const app = new GuRoot();
 
 export const stacks: CloudwatchLogsManagementProps[] = [
 	{ stack: 'print-production' },
-	{ stack: 'deploy' },
+	{ stack: 'deploy', logShippingPrefixes: ['/aws/lambda', '/aws/cloudtrail'] },
 	{ stack: 'flexible' },
 	{ stack: 'workflow' },
-	{ stack: 'media-service',
-		logShippingPrefixes: [
-			'/aws/lambda',
-			'/aws/transfer'
-		],
+	{
+		stack: 'media-service',
+		logShippingPrefixes: ['/aws/lambda', '/aws/transfer'],
 	},
 	{ stack: 'content-api' },
 	{ stack: 'cms-fronts' },
@@ -45,7 +43,7 @@ export const stacks: CloudwatchLogsManagementProps[] = [
 		],
 	},
 	{ stack: 'playground' },
-	{ stack: 'ai' }
+	{ stack: 'ai' },
 ];
 
 stacks.forEach((stack) => new CloudwatchLogsManagement(app, stack));


### PR DESCRIPTION
## What does this change?
Ships log groups prefixed `/aws/cloudtrail` in addition to the default `/aws/lambda` from the DevX account.

This ships CloudTrail logs to Central ELK for simple interrogation.

## What testing has been performed for this change?
[Deployed](https://riffraff.gutools.co.uk/deployment/view/3a5501a4-41ef-4e3f-83b9-9daa7ec99048), and observed the [logs in Central ELK](https://logs.gutools.co.uk/s/devx/goto/4c146d10-1dc3-11ef-94df-21eb35cc3901).