### PR TITLE
Add interactives aws account to cloudwatch logs management

### DIFF
--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -21,6 +21,7 @@ export const stacks: CloudwatchLogsManagementProps[] = [
 	{ stack: 'ophan' },
 	{ stack: 'frontend' },
 	{ stack: 'identity' },
+	{ stack: 'interactives' },
 	{ stack: 'mobile' },
 	{ stack: 'security' },
 	{ stack: 'personalisation' },


### PR DESCRIPTION
So that we can ship logs for the new gudocs app
