### PR TITLE
Add membership to logs-management but only to use retention periods

### DIFF
--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -45,6 +45,13 @@ export const stacks: CloudwatchLogsManagementProps[] = [
 			'/aws/lambda/transcription-service',
 		],
 	},
+	{
+		stack: 'membership',
+		retentionInDays: 14,
+// Using this to programmatically set the retention time for logs in the membership account.
+// Some logs in the membership stack contain pii-data, so we do not want to send any logs outside of AWS to minimise effort needed for GDPR compliance.
+		logShippingPrefixes: [],
+	},
 	{ stack: 'playground' },
 	{ stack: 'ai' }
 ];


### PR DESCRIPTION
## What does this change?
This change adds the membership stack to cloudwatch-logs-management to take advantage of the retention-period setting.
Currently too many logs in membership contain PII data so for now we do not want to send any membership logs to kibana.
As such I have set `logShippingPrefixes` to be an empty array. The hope is that this will not show up as an undefined parameter in the interface and so wont be overwritten by the default prefix of '/aws/lambda' .

## What testing has been performed for this change?
<!-- 
Due to the nature of this project, there is no pre-production environment available for testing changes. Consequently, we recommend using Riff-Raff to deploy 
your branch to an individual account (rather than all accounts, which is the default!) in order to validate your changes in production. 

In order to do this, select `Preview` from the deployment page (instead of `Deploy Now`). 
Next `Deselect all` and then manually select all deployment tasks for a specific account. 
Once you’ve done this you can `Preview with selections`, check the list of tasks and then `Deploy`. 
-->

## How can we measure success?
<!-- 
Do you expect errors to decrease, or performance to improve? 
What can be used to prove this? A filtered view of logs or analytics, etc? 
-->

## Have we considered potential risks?
<!-- 
What are the potential risks and how can they be mitigated?
Does the change add or remove a feature, significantly alter AWS resources or introduce some other form of risk? 
If so, you might also want to inform the teams who own the affected AWS accounts via Chat/email so they can keep an eye out for any problems. 
-->
