### PR TITLE
add logs management classes to handle logs containing PII data

### DIFF
--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -1,7 +1,9 @@
 import 'source-map-support/register';
 import { GuRoot } from "@guardian/cdk/lib/constructs/root";
-import type { CloudwatchLogsManagementProps, CloudwatchLogsManagementForPIIDataProps } from '../lib/cloudwatch-logs-management';
-import { CloudwatchLogsManagement, CloudwatchLogsManagementForPIIData } from '../lib/cloudwatch-logs-management';
+import { CloudwatchLogsManagement } from '../lib/cloudwatch-logs-management';
+import type { CloudwatchLogsManagementProps } from '../lib/cloudwatch-logs-management';
+import { CloudwatchLogsManagementForPIIData } from '../lib/cloudwatch-logs-management-for-pii-data';
+import type { CloudwatchLogsManagementForPIIDataProps } from '../lib/cloudwatch-logs-management-for-pii-data';
 
 const app = new GuRoot();
 

--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -1,7 +1,7 @@
 import 'source-map-support/register';
 import { GuRoot } from "@guardian/cdk/lib/constructs/root";
-import type { CloudwatchLogsManagementProps } from '../lib/cloudwatch-logs-management';
-import { CloudwatchLogsManagement } from '../lib/cloudwatch-logs-management';
+import type { CloudwatchLogsManagementProps, CloudwatchLogsManagementForPIIDataProps } from '../lib/cloudwatch-logs-management';
+import { CloudwatchLogsManagement, CloudwatchLogsManagementForPIIData } from '../lib/cloudwatch-logs-management';
 
 const app = new GuRoot();
 
@@ -49,4 +49,12 @@ export const stacks: CloudwatchLogsManagementProps[] = [
 	{ stack: 'ai' }
 ];
 
+export const stacksWithPII: CloudwatchLogsManagementForPIIDataProps[] = [
+	{
+		stack: 'membership',
+			retentionInDays: 14,
+	},
+]
+
 stacks.forEach((stack) => new CloudwatchLogsManagement(app, stack));
+stacksWithPII.forEach((stack) => new CloudwatchLogsManagementForPIIData(app, stack));

--- a/packages/cdk/lib/__snapshots__/cloudwatch-logs-management-for-pii-data.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudwatch-logs-management-for-pii-data.test.ts.snap
@@ -1,0 +1,950 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The CloudwatchLogsManagement stack matches the snapshot 1`] = `
+{
+  "Metadata": {
+    "gu:cdk:constructs": [
+      "GuStringParameter",
+      "GuS3Bucket",
+      "GuDistributionBucketParameter",
+      "GuScheduledLambda",
+      "GuLambdaFunction",
+      "GuScheduledLambda",
+    ],
+    "gu:cdk:version": "TEST",
+  },
+  "Parameters": {
+    "DistributionBucketName": {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "KinesisStreamArn": {
+      "Default": "/account/services/logging.stream",
+      "Description": "The ARN (not name) of the kinesis stream to ship logs to",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "DisableCloudWatchLoggingPolicy566D41D3": {
+      "Properties": {
+        "Description": "",
+        "Path": "/",
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Deny",
+              "Resource": "arn:aws:logs:*:*:*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::ManagedPolicy",
+    },
+    "SetLogShippingFunc": {
+      "DependsOn": [
+        "setlogshippingServiceRoleDefaultPolicy21BAA7D8",
+        "setlogshippingServiceRoleFD6872A4",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "deploy/PROD/set-log-shipping/set-log-shipping.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "set-log-shipping",
+            "LOG_KINESIS_STREAM": {
+              "Ref": "KinesisStreamArn",
+            },
+            "LOG_NAME_PREFIXES": "/aws/lambda",
+            "LOG_SHIPPING_LAMBDA_ARN": {
+              "Fn::GetAtt": [
+                "ShipLogEntriesFunc",
+                "Arn",
+              ],
+            },
+            "STACK": "deploy",
+            "STAGE": "PROD",
+            "STRUCTURED_DATA_BUCKET": {
+              "Ref": "StructuredFieldsBucket",
+            },
+          },
+        },
+        "Handler": "handlers.setLogShipping",
+        "LoggingConfig": {
+          "LogFormat": "JSON",
+        },
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "setlogshippingServiceRoleFD6872A4",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "set-log-shipping",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cloudwatch-logs-management",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Timeout": 60,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "SetLogShippingPolicy0F235CDA": {
+      "Properties": {
+        "Description": "",
+        "Path": "/",
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "logs:DescribeLogGroups",
+                "logs:DescribeSubscriptionFilters",
+                "logs:PutSubscriptionFilter",
+                "logs:DeleteSubscriptionFilter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:logs:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":log-group:*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "lambda:ListFunctions",
+                "lambda:ListTags",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            {
+              "Action": [
+                "ecs:ListTaskDefinitions",
+                "ecs:DescribeTaskDefinition",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            {
+              "Action": "s3:PutObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "StructuredFieldsBucket",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::ManagedPolicy",
+    },
+    "SetRetentionFunc": {
+      "DependsOn": [
+        "setretentionServiceRoleDefaultPolicyCEB3697A",
+        "setretentionServiceRoleF411F948",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "deploy/PROD/set-retention/set-retention.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "set-retention",
+            "RETENTION_IN_DAYS": "7",
+            "STACK": "deploy",
+            "STAGE": "PROD",
+          },
+        },
+        "Handler": "handlers.setRetention",
+        "LoggingConfig": {
+          "LogFormat": "JSON",
+        },
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "setretentionServiceRoleF411F948",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "set-retention",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cloudwatch-logs-management",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Timeout": 60,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "SetRetentionPolicy7B345D11": {
+      "Properties": {
+        "Description": "",
+        "Path": "/",
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "logs:DescribeLogGroups",
+                "logs:PutRetentionPolicy",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:logs:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":log-group:*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::ManagedPolicy",
+    },
+    "ShipLogEntriesFunc": {
+      "DependsOn": [
+        "shiplogentriesServiceRoleDefaultPolicy372B39B1",
+        "shiplogentriesServiceRoleB4E65CC2",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "deploy/PROD/ship-log-entries/ship-log-entries.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "ship-log-entries",
+            "LOG_KINESIS_STREAM": {
+              "Ref": "KinesisStreamArn",
+            },
+            "STACK": "deploy",
+            "STAGE": "PROD",
+            "STRUCTURED_DATA_BUCKET": {
+              "Ref": "StructuredFieldsBucket",
+            },
+          },
+        },
+        "Handler": "handlers.shipLogEntries",
+        "LoggingConfig": {
+          "LogFormat": "JSON",
+        },
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "shiplogentriesServiceRoleB4E65CC2",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "ship-log-entries",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cloudwatch-logs-management",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Timeout": 5,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ShipLogEntriesPolicyCE9979ED": {
+      "Properties": {
+        "Description": "",
+        "Path": "/",
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "kinesis:PutRecords",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "KinesisStreamArn",
+              },
+            },
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "StructuredFieldsBucket",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::ManagedPolicy",
+    },
+    "StructuredFieldsBucket": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "cloudwatch-logs-management",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cloudwatch-logs-management",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "setlogshippingServiceRoleDefaultPolicy21BAA7D8": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/deploy/PROD/set-log-shipping/set-log-shipping.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/deploy/set-log-shipping",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/deploy/set-log-shipping/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "setlogshippingServiceRoleDefaultPolicy21BAA7D8",
+        "Roles": [
+          {
+            "Ref": "setlogshippingServiceRoleFD6872A4",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "setlogshippingServiceRoleFD6872A4": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+          {
+            "Ref": "SetLogShippingPolicy0F235CDA",
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "set-log-shipping",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cloudwatch-logs-management",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "setlogshippingsetlogshippingrate10minutes07B669287": {
+      "Properties": {
+        "ScheduleExpression": "rate(10 minutes)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "SetLogShippingFunc",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "setlogshippingsetlogshippingrate10minutes0AllowEventRuleCloudwatchLogsManagementdeploysetlogshipping1BFA79438197006B": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "SetLogShippingFunc",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "setlogshippingsetlogshippingrate10minutes07B669287",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "setretentionServiceRoleDefaultPolicyCEB3697A": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/deploy/PROD/set-retention/set-retention.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/deploy/set-retention",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/deploy/set-retention/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "setretentionServiceRoleDefaultPolicyCEB3697A",
+        "Roles": [
+          {
+            "Ref": "setretentionServiceRoleF411F948",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "setretentionServiceRoleF411F948": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+          {
+            "Ref": "SetRetentionPolicy7B345D11",
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "set-retention",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cloudwatch-logs-management",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "setretentionsetretentionrate1hour0AllowEventRuleCloudwatchLogsManagementdeploysetretentionD9A0E7537297E68D": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "SetRetentionFunc",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "setretentionsetretentionrate1hour0DA4C9A13",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "setretentionsetretentionrate1hour0DA4C9A13": {
+      "Properties": {
+        "ScheduleExpression": "rate(1 hour)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "SetRetentionFunc",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "shiplogentriesServiceRoleB4E65CC2": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+          {
+            "Ref": "ShipLogEntriesPolicyCE9979ED",
+          },
+          {
+            "Ref": "DisableCloudWatchLoggingPolicy566D41D3",
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "ship-log-entries",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cloudwatch-logs-management",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "shiplogentriesServiceRoleDefaultPolicy372B39B1": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/deploy/PROD/ship-log-entries/ship-log-entries.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/deploy/ship-log-entries",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/deploy/ship-log-entries/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "shiplogentriesServiceRoleDefaultPolicy372B39B1",
+        "Roles": [
+          {
+            "Ref": "shiplogentriesServiceRoleB4E65CC2",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "shiplogentriesShipLogEntriesPermission390E0555": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "ShipLogEntriesFunc",
+            "Arn",
+          ],
+        },
+        "Principal": "logs.eu-west-1.amazonaws.com",
+        "SourceAccount": {
+          "Ref": "AWS::AccountId",
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+  },
+}
+`;

--- a/packages/cdk/lib/cloudwatch-logs-management-for-pii-data.test.ts
+++ b/packages/cdk/lib/cloudwatch-logs-management-for-pii-data.test.ts
@@ -1,0 +1,12 @@
+import { App } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { CloudwatchLogsManagement } from './cloudwatch-logs-management';
+
+describe('The CloudwatchLogsManagement stack', () => {
+	it('matches the snapshot', () => {
+		const app = new App();
+		const stack = new CloudwatchLogsManagement(app, { stack: 'deploy' });
+		const template = Template.fromStack(stack);
+		expect(template.toJSON()).toMatchSnapshot();
+	});
+});

--- a/packages/cdk/lib/cloudwatch-logs-management-for-pii-data.ts
+++ b/packages/cdk/lib/cloudwatch-logs-management-for-pii-data.ts
@@ -1,0 +1,79 @@
+import { GuScheduledLambda } from '@guardian/cdk';
+import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
+import { GuStack, GuStringParameter } from '@guardian/cdk/lib/constructs/core';
+import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
+//import { GuS3Bucket } from '@guardian/cdk/lib/constructs/s3';
+import type { App } from 'aws-cdk-lib';
+import { Duration } from 'aws-cdk-lib';
+import { Schedule } from 'aws-cdk-lib/aws-events';
+import {
+	Effect,
+	ManagedPolicy,
+	PolicyStatement,
+//	ServicePrincipal,
+} from 'aws-cdk-lib/aws-iam';
+import { Runtime } from 'aws-cdk-lib/aws-lambda';
+
+export interface CloudwatchLogsManagementForPIIDataProps
+	extends Omit<GuStackProps, 'stage' | 'env'> {
+	retentionInDays?: number;
+}
+
+export class CloudwatchLogsManagementForPIIData extends GuStack {
+	constructor(scope: App, props: CloudwatchLogsManagementForPIIDataProps) {
+		const {
+			stack,
+			retentionInDays = 7,
+		} = props;
+
+		// The ID will become `CloudwatchLogsManagement-<STACK>`
+		const id = `${CloudwatchLogsManagementForPIIData.prototype.constructor.name}-${stack}`;
+
+		super(scope, id, {
+			...props,
+			stack,
+
+			/*
+			 These lambdas do not like siblings!
+			 In the past, when more than one instance existed in an account/region, terrible things happened!
+			 We now only ever deploy to one stage - PROD.
+			 @see https://docs.google.com/document/d/1HNEo6UKQ-JhoXHp0mr-KuGC1Ra_8_BfwSuPq3VgO0AI/edit#
+			 */
+			stage: 'PROD',
+			env: {
+				region: 'eu-west-1',
+			},
+		});
+
+		const { region, account } = this;
+
+		const setPIIDataRetentionLambda = new GuScheduledLambda(this, 'set-pii-data-retention', {
+			app: 'set-pii-data-retention',
+			runtime: Runtime.NODEJS_20_X,
+			fileName: 'set-pii-data-retention.zip',
+			handler: 'handlers.setPIIDataRetention',
+			rules: [{ schedule: Schedule.rate(Duration.hours(1)) }],
+			monitoringConfiguration: { noMonitoring: true },
+			environment: {
+				RETENTION_IN_DAYS: retentionInDays.toString(),
+			},
+			timeout: Duration.minutes(1),
+		});
+
+		this.overrideLogicalId(setPIIDataRetentionLambda, {
+			logicalId: 'SetPIIDataRetentionFunc',
+			reason: 'Migrating from YAML',
+		});
+
+		const setRetentionPolicy = new ManagedPolicy(this, 'SetPIIDataRetentionPolicy', {
+			statements: [
+				new PolicyStatement({
+					effect: Effect.ALLOW,
+					actions: ['logs:DescribeLogGroups', 'logs:PutRetentionPolicy'],
+					resources: [`arn:aws:logs:${region}:${account}:log-group:*`],
+				}),
+			],
+		});
+		setPIIDataRetentionLambda.role?.addManagedPolicy(setRetentionPolicy);
+	}
+}

--- a/packages/cdk/lib/cloudwatch-logs-management-for-pii-data.ts
+++ b/packages/cdk/lib/cloudwatch-logs-management-for-pii-data.ts
@@ -1,8 +1,6 @@
 import { GuScheduledLambda } from '@guardian/cdk';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
-import { GuStack, GuStringParameter } from '@guardian/cdk/lib/constructs/core';
-import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
-//import { GuS3Bucket } from '@guardian/cdk/lib/constructs/s3';
+import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import type { App } from 'aws-cdk-lib';
 import { Duration } from 'aws-cdk-lib';
 import { Schedule } from 'aws-cdk-lib/aws-events';
@@ -10,7 +8,6 @@ import {
 	Effect,
 	ManagedPolicy,
 	PolicyStatement,
-//	ServicePrincipal,
 } from 'aws-cdk-lib/aws-iam';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 


### PR DESCRIPTION
## What does this change?
This is a rival approach to https://github.com/guardian/cloudwatch-logs-management/pull/334.
This approach creates a seperate task and to manage logs containing PII data. This allows us to explicitly define these stacks and manage the retention period for these logs.
This approach also means that stacks that are not intending to migrate any logs outside of AWS do not have resources built that exist to do this.

## What testing has been performed for this change?
<!-- 
Due to the nature of this project, there is no pre-production environment available for testing changes. Consequently, we recommend using Riff-Raff to deploy 
your branch to an individual account (rather than all accounts, which is the default!) in order to validate your changes in production. 

In order to do this, select `Preview` from the deployment page (instead of `Deploy Now`). 
Next `Deselect all` and then manually select all deployment tasks for a specific account. 
Once you’ve done this you can `Preview with selections`, check the list of tasks and then `Deploy`. 
-->

## How can we measure success?
<!-- 
Do you expect errors to decrease, or performance to improve? 
What can be used to prove this? A filtered view of logs or analytics, etc? 
-->

## Have we considered potential risks?
<!-- 
What are the potential risks and how can they be mitigated?
Does the change add or remove a feature, significantly alter AWS resources or introduce some other form of risk? 
If so, you might also want to inform the teams who own the affected AWS accounts via Chat/email so they can keep an eye out for any problems. 
-->
