### PR TITLE
Only create transfer lambda and resources if stack contains no pii data

### DIFF
--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -54,4 +54,5 @@ export const stacks: CloudwatchLogsManagementProps[] = [
 	}
 ];
 
-stacks.forEach((stack) => new CloudwatchLogsManagement(app, stack));
+stacks.forEach((stack) => { new CloudwatchLogsManagement(app, stack)});
+

--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -45,10 +45,7 @@ export const stacks: CloudwatchLogsManagementProps[] = [
 			'/aws/lambda/transcription-service',
 		],
 	},
-	{
-		stack: 'playground',
-		containsPIIData: true,
-	},
+	{ stack: 'playground' },
 	{ stack: 'ai' },
 	{
 		stack: 'membership',

--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -46,7 +46,12 @@ export const stacks: CloudwatchLogsManagementProps[] = [
 		],
 	},
 	{ stack: 'playground' },
-	{ stack: 'ai' }
+	{ stack: 'ai' },
+	{
+		stack: 'membership',
+		retentionInDays: 14,
+		containsPIIData: true,
+	}
 ];
 
 stacks.forEach((stack) => new CloudwatchLogsManagement(app, stack));

--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -45,7 +45,10 @@ export const stacks: CloudwatchLogsManagementProps[] = [
 			'/aws/lambda/transcription-service',
 		],
 	},
-	{ stack: 'playground' },
+	{
+		stack: 'playground',
+		containsPIIData: true,
+	},
 	{ stack: 'ai' },
 	{
 		stack: 'membership',

--- a/packages/cdk/lib/__snapshots__/cloudwatch-logs-management.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudwatch-logs-management.test.ts.snap
@@ -4,10 +4,10 @@ exports[`The CloudwatchLogsManagement stack matches the snapshot 1`] = `
 {
   "Metadata": {
     "gu:cdk:constructs": [
-      "GuStringParameter",
-      "GuS3Bucket",
       "GuDistributionBucketParameter",
       "GuScheduledLambda",
+      "GuS3Bucket",
+      "GuStringParameter",
       "GuLambdaFunction",
       "GuScheduledLambda",
     ],

--- a/packages/cdk/lib/cloudwatch-logs-management.test.ts
+++ b/packages/cdk/lib/cloudwatch-logs-management.test.ts
@@ -1,6 +1,8 @@
 import { App } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
+import {stacks} from "../bin/cdk";
 import { CloudwatchLogsManagement } from './cloudwatch-logs-management';
+
 
 describe('The CloudwatchLogsManagement stack', () => {
 	it('matches the snapshot', () => {
@@ -8,5 +10,18 @@ describe('The CloudwatchLogsManagement stack', () => {
 		const stack = new CloudwatchLogsManagement(app, { stack: 'deploy' });
 		const template = Template.fromStack(stack);
 		expect(template.toJSON()).toMatchSnapshot();
+	});
+});
+
+
+// If stack contains PII data it should have a retention period of max 14 days (See list of retention presets here:
+// https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutRetentionPolicy.html).
+describe('Stacks with containsPIIData set to true', () => {
+	it('have retentionInDays <= 14', () => {
+		stacks.forEach((stack) => {
+			if (stack.containsPIIData && stack.retentionInDays) {
+				expect(stack.retentionInDays <= 14).toBe(true);
+			};
+		});
 	});
 });


### PR DESCRIPTION
## What does this change?
I wanted to use cloudwatch-logs-management to handle the log retention periods for the membership stack, however because a many log groups in this stack contain PII data, the team is adamant they do not want any of the Log shipping functionality to be generated in membership.

I made the following changes to allow membership (and any other stacks that contain PII data) to use this app:

- Added a new optional field containsPIIData: boolean to the CloudwatchLogsManagementProps interface;
- Moved the cdk code to generate the log-shipping lambda and related resources behind an if() condition, so that they will only generate for stacks where containsPIIData is not set to 'true'.

This will be very useful for any stacks that contains PII data in their log groups as it will now only generate the "set-retention" Lambdas for these groups (Log groups with PII data must not be transferred out of AWS).
 
This will enable us to easily set the retention period for these stacks, ensuring any PII data in the logs is removed within the 30 days window afforded us by Subject Access Requests and Right to Erasure Requests.

I have also added a test to ensure any stacks with containsPIIData set to true have their retentionInDays set to 14 or less.
It has to be a max of 14 as [aws only allows the retention periods to be preset values](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutRetentionPolicy.html#:~:text=Required%3A%20Yes-,retentionInDays,-The%20number%20of). The next retention value after 14 is 30 days and this is too risky as it is right on the maximum grace period allowed for SAR and RER. 

## What testing has been performed for this change?
1) This change has been deployed to the membership account with the "containsPIIData" field set to true for that account.
It was confirmed that the cloudwatch-logs-management stack was created in membership account with only the SetRetention lambda and its associated infrastructure.

2) This change has been deployed to the developer-playground account with the "containsPIIData" flag set to false for that account. This account contains a pre-existing cloudwatch-logs-management stack with the both the SetRetention and Transfer lambdas with their associated infrastructure.
It was confirmed that after the deploy, the cloudwatch-logs-management stack was unchganged, but that the "Last Modified" times for the resources corresponded to the time of the deploy, indicating the deploy had successfully rebuilt all the resources as expected without making any changes to the stack.

3) Set "containsPIIData" flag to true for developer-playground account to ensure that if flag is set on an account with an existing cloudwatch-logs-management stack, that it would remove all the transfer resources. Needed to use "unsafe deploy" to allow for deletion of resources. Confirmed that after deploy, the log-shipping lambda and associated resources had been removed.

4) Added a test to cloudwatch-logs-managements.tests.ts to check that any stack with containsPIIData set to 'true' has a retentionInDays value less than 14 (undefined retention in days will default to 7 so they are ignored). 

<!-- 
Due to the nature of this project, there is no pre-production environment available for testing changes. Consequently, we recommend using Riff-Raff to deploy 
your branch to an individual account (rather than all accounts, which is the default!) in order to validate your changes in production. 

In order to do this, select `Preview` from the deployment page (instead of `Deploy Now`). 
Next `Deselect all` and then manually select all deployment tasks for a specific account. 
Once you’ve done this you can `Preview with selections`, check the list of tasks and then `Deploy`. 
-->

## How can we measure success?
<!-- 
Do you expect errors to decrease, or performance to improve? 
What can be used to prove this? A filtered view of logs or analytics, etc? 
-->

## Have we considered potential risks?
<!-- 
What are the potential risks and how can they be mitigated?
Does the change add or remove a feature, significantly alter AWS resources or introduce some other form of risk? 
If so, you might also want to inform the teams who own the affected AWS accounts via Chat/email so they can keep an eye out for any problems. 
-->
