### PR TITLE
Update README.md to clarify when we mean deployment-resource-stack rather than cloudformation stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ To deploy this service into a new account:
   1. Prepare your account. The following SSM parameters need to exist:
      - `/account/services/artifact.bucket`
      - `/account/services/logging.stream`
-  2. Raise a PR, adding your [deployment-stack](https://riffraff.gutools.co.uk/deployinfo/data?key=credentials%3Aaws-cfn-role) to [`packages/cdk/bin/cdk.ts`](packages/cdk/bin/cdk.ts)
+  2. Raise a PR, adding your [deployment-stack](https://riffraff.gutools.co.uk/deployinfo/data?key=credentials%3Aaws-cfn-role) to [`packages/cdk/bin/cdk.ts`](packages/cdk/bin/cdk.ts):
+     - For deployment-stacks with logs that contain PII data, add use the `retentionOnlyStacks` array. 
+     - For all other deployment-stacks, use the `retentionAndTransferStacks` array.
   3. Merge the PR; Riff-Raff is configured to continuously deploy this service
   4. In order for shipped logs appear in Kibana, add the Kinesis stream source from the `aws-account-setup` infrastructure stack to this [file](https://github.com/guardian/deploy-tools-platform/blob/main/elk/src/source.config.ts).
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To deploy this service into a new account:
   1. Prepare your account. The following SSM parameters need to exist:
      - `/account/services/artifact.bucket`
      - `/account/services/logging.stream`
-  2. Raise a PR, adding your stack to [`packages/cdk/bin/cdk.ts`](packages/cdk/bin/cdk.ts)
+  2. Raise a PR, adding your [deployment-stack](https://riffraff.gutools.co.uk/deployinfo/data?key=credentials%3Aaws-cfn-role) to [`packages/cdk/bin/cdk.ts`](packages/cdk/bin/cdk.ts)
   3. Merge the PR; Riff-Raff is configured to continuously deploy this service
   4. In order for shipped logs appear in Kibana, add the Kinesis stream source from the `aws-account-setup` infrastructure stack to this [file](https://github.com/guardian/deploy-tools-platform/blob/main/elk/src/source.config.ts).
 

--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ To deploy this service into a new account:
   1. Prepare your account. The following SSM parameters need to exist:
      - `/account/services/artifact.bucket`
      - `/account/services/logging.stream`
-  2. Raise a PR, adding your [deployment-resource-stack](https://riffraff.gutools.co.uk/deployinfo/data?key=credentials%3Aaws-cfn-role) to [`packages/cdk/bin/cdk.ts`](packages/cdk/bin/cdk.ts):
+  2. Raise a PR, adding your deployment-resource-stack (obtained from [riffraff](https://riffraff.gutools.co.uk/)) to [`packages/cdk/bin/cdk.ts`](packages/cdk/bin/cdk.ts):
      - For deployment-resource-stacks with logs that contain PII data, use the `retentionOnlyStacks` array. 
      - For all other deployment-resource-stacks, use the `retentionAndTransferStacks` array.
-  3. Merge the PR; Riff-Raff is configured to continuously deploy this service
-  4. In order for shipped logs appear in Kibana, add the Kinesis stream source from the `aws-account-setup` infrastructure stack to this [file](https://github.com/guardian/deploy-tools-platform/blob/main/elk/src/source.config.ts).
+  4. Merge the PR; Riff-Raff is configured to continuously deploy this service
+  5. In order for shipped logs appear in Kibana, add the Kinesis stream source from the `aws-account-setup` infrastructure stack to this [file](https://github.com/guardian/deploy-tools-platform/blob/main/elk/src/source.config.ts).
 
 ## Development
 ### Requirements

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ To deploy this service into a new account:
   1. Prepare your account. The following SSM parameters need to exist:
      - `/account/services/artifact.bucket`
      - `/account/services/logging.stream`
-  2. Raise a PR, adding your [deployment-stack](https://riffraff.gutools.co.uk/deployinfo/data?key=credentials%3Aaws-cfn-role) to [`packages/cdk/bin/cdk.ts`](packages/cdk/bin/cdk.ts):
-     - For deployment-stacks with logs that contain PII data, add use the `retentionOnlyStacks` array. 
-     - For all other deployment-stacks, use the `retentionAndTransferStacks` array.
+  2. Raise a PR, adding your [deployment-resource-stack](https://riffraff.gutools.co.uk/deployinfo/data?key=credentials%3Aaws-cfn-role) to [`packages/cdk/bin/cdk.ts`](packages/cdk/bin/cdk.ts):
+     - For deployment-resource-stacks with logs that contain PII data, add use the `retentionOnlyStacks` array. 
+     - For all other deployment-resource-stacks, use the `retentionAndTransferStacks` array.
   3. Merge the PR; Riff-Raff is configured to continuously deploy this service
   4. In order for shipped logs appear in Kibana, add the Kinesis stream source from the `aws-account-setup` infrastructure stack to this [file](https://github.com/guardian/deploy-tools-platform/blob/main/elk/src/source.config.ts).
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To deploy this service into a new account:
      - `/account/services/artifact.bucket`
      - `/account/services/logging.stream`
   2. Raise a PR, adding your [deployment-resource-stack](https://riffraff.gutools.co.uk/deployinfo/data?key=credentials%3Aaws-cfn-role) to [`packages/cdk/bin/cdk.ts`](packages/cdk/bin/cdk.ts):
-     - For deployment-resource-stacks with logs that contain PII data, add use the `retentionOnlyStacks` array. 
+     - For deployment-resource-stacks with logs that contain PII data, use the `retentionOnlyStacks` array. 
      - For all other deployment-resource-stacks, use the `retentionAndTransferStacks` array.
   3. Merge the PR; Riff-Raff is configured to continuously deploy this service
   4. In order for shipped logs appear in Kibana, add the Kinesis stream source from the `aws-account-setup` infrastructure stack to this [file](https://github.com/guardian/deploy-tools-platform/blob/main/elk/src/source.config.ts).

--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -8,6 +8,8 @@ const app = new GuRoot();
 
 // The word "stack" in this file refers to the deployment-resources-stacks in riffraff. These stacks map roughly to aws accounts.
 
+// Adding stacks here will manage log retention without transfer of logs to the ELK stack.
+// This is mainly for stacks whose logs contain PII data.
 export const retentionOnlyStacks: CloudwatchLogsManagementProps[] = [
 	{
 		stack: 'membership',

--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -6,6 +6,8 @@ import {CloudwatchLogsRetention} from "../lib/cloudwatch-logs-retention";
 
 const app = new GuRoot();
 
+// The word "stack" in this file refers to the deployment-resources-stacks in riffraff. These stacks map roughly to aws accounts.
+
 export const retentionOnlyStacks: CloudwatchLogsManagementProps[] = [
 	{
 		stack: 'membership',


### PR DESCRIPTION
## What does this change?
- Reword the readme slightly to use deployment-resource-stack instead of just stack when thats what we mean.
- Add instructions to readme for adding deployment-resource-stacks with logs that contain PII data.
- Add comments to cdk.ts that specify what we mean by 'stack' in this file
- Add comment above [retentionOnlyStacks](https://github.com/guardian/cloudwatch-logs-management/blob/61c3ad31cd9ee7977cc43dd08cb2fdbf50e462ff/packages/cdk/bin/cdk.ts#L13) to explain what its for and recommend it for stacks that have logs with PII data.

## Why we need these changes##
[A stack by any other name...](https://github.com/guardian/cloudwatch-logs-management/pull/346/commits/8c6858a9b21aad7c1020a135a7e7e41ab64fe039)
The readme uses the word stack to mean both cloudformation stack and deployment-resource-stack in different places.

The word "stack" is horribly overloaded and most folk I speak to outside of devX see it exclusively in the context of Cloudformation Stacks. This can lead to a lot of confusion when we use it in the other sence.

I am hoping this rewording and the addition of a link to the riffraff deployment-resource-stacks list will make this a bit clearer.

[add comment describing use of retentionOnlyStacks](https://github.com/guardian/cloudwatch-logs-management/pull/346/commits/c1796e05ebbb4c53246b2d45843bf294c057687d)
Leftover work from https://github.com/guardian/cloudwatch-logs-management/pull/338 This comment just makes it clear what the retentionOnlyStacks array is for and includes a reminder to use it if PII data is involved.

[Expand step 2 in readme to include instructions for stacks that have logs with PII data](https://github.com/guardian/cloudwatch-logs-management/pull/346/commits/ce4037cd0bf37163a9500b5864b523823fc5d79c):
Currently there were no instructions to specify what to do if your deployment-resource-stack had logs with PII data.
This change adds a step to the readme to explain which array to add your stack to in cdk.ts


## What testing has been performed for this change?
No functional changes.

## How can we measure success?
The readme is less confusing

## Have we considered potential risks?
No functional changes.