### PR TITLE
Add a logs management stack for the editorial-feeds account

### DIFF
--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -19,6 +19,7 @@ export const retentionOnlyStacks: CloudwatchLogsManagementProps[] = [
 
 export const retentionAndTransferStacks: CloudwatchLogsManagementProps[] = [
 	{ stack: 'print-production' },
+	{ stack: 'editorial-feeds' },
 	{ stack: 'deploy' },
 	{ stack: 'flexible' },
 	{ stack: 'workflow' },


### PR DESCRIPTION
## What does this change?

Adds a new logs management stack to the editorial-feeds account, to provide log shipping for new lambdas in that account.

## What testing has been performed for this change?

N/A - happy to take suggestions

## How can we measure success?

Logs from new lambdas in the editorial-feeds account are available in central ELK

## Have we considered potential risks?


