### PR TITLE
Add transcription-service prefix to investigations logs

### DIFF
--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -56,6 +56,7 @@ export const retentionAndTransferStacks: CloudwatchLogsManagementProps[] = [
 			'fb-ad-library',
 			'lurch',
 			'/aws/lambda/transcription-service',
+			'transcription-service'
 		],
 	},
 	{ stack: 'playground' },


### PR DESCRIPTION
## What does this change?
We are introducing some fargate tasks to the transcription service (https://github.com/guardian/transcription-service). This change will ensure that the logs from those tasks are shipped to central ELK.

## What testing has been performed for this change?
None
