### PR TITLE
Deploy service to the hiring-and-onboarding account

### DIFF
--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -62,6 +62,7 @@ export const retentionAndTransferStacks: CloudwatchLogsManagementProps[] = [
 	},
 	{ stack: 'playground' },
 	{ stack: 'ai' },
+	{ stack: 'hiring-and-onboarding' },
 ];
 
 export const allRetentionStacks = retentionOnlyStacks.concat(retentionAndTransferStacks);


### PR DESCRIPTION
## What does this change?
Deploys this service to the hiring-and-onboarding account to allow for lambda logs to be shipped to Central ELK.
