### PR TITLE
Update Dependabot schedule interval to quarterly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     directory: '/'
     schedule:
       # This repository does not run in a context that is accessible by users or external requests. Run Dependabot once a month to reduce the frequency of PRs.
-      interval: 'monthly'
+      interval: 'quarterly'
     commit-message:
       prefix: "chore(deps): "
     


### PR DESCRIPTION
## What does this change?

Updates the Dependabot schedule interval from the current value to `quarterly`, so dependency update PRs are raised on the first day of each quarter (January, April, July, October).

